### PR TITLE
Fixed some internal errors caused by using /f wild and a placeholder issue

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdJoin.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdJoin.java
@@ -115,8 +115,6 @@ public class CmdJoin extends FCommand {
             fplayer.msg(TL.COMMAND_JOIN_MOVED, context.fPlayer.describeTo(fplayer, true), faction.getTag(fplayer));
         }
 
-        faction.msg(TL.COMMAND_JOIN_JOINED, fplayer.describeTo(faction, true));
-
         fplayer.resetFactionData();
 
         if (faction.altInvited(fplayer)) {
@@ -143,6 +141,8 @@ public class CmdJoin extends FCommand {
         } catch (HierarchyException e) {
             System.out.print(e.getMessage());
         }
+
+        faction.msg(TL.COMMAND_JOIN_JOINED, fplayer.describeTo(faction, true));
 
         if (Conf.logFactionJoin) {
             if (samePlayer) {

--- a/src/main/java/com/massivecraft/factions/cmd/wild/CmdWild.java
+++ b/src/main/java/com/massivecraft/factions/cmd/wild/CmdWild.java
@@ -75,6 +75,7 @@ public class CmdWild extends FCommand implements WaitedTask {
         }
         if (!success) {
             p.sendMessage(TL.COMMAND_WILD_FAILED.toString());
+            teleportRange.remove(p);
         }
     }
 
@@ -114,6 +115,7 @@ public class CmdWild extends FCommand implements WaitedTask {
     @Override
     public void handleFailure(Player player) {
         player.sendMessage(TL.COMMAND_WILD_INTERUPTED.toString());
+        teleportRange.remove(player);
     }
 
 }

--- a/src/main/java/com/massivecraft/factions/cmd/wild/CmdWild.java
+++ b/src/main/java/com/massivecraft/factions/cmd/wild/CmdWild.java
@@ -46,8 +46,6 @@ public class CmdWild extends FCommand implements WaitedTask {
     public void perform(CommandContext context) {
         if (!teleportRange.containsKey(context.player)) {
             context.player.openInventory(new WildGUI(context.player, context.fPlayer).getInventory());
-        } else {
-            context.fPlayer.msg(TL.COMMAND_WILD_WAIT);
         }
     }
 

--- a/src/main/java/com/massivecraft/factions/tag/FactionTag.java
+++ b/src/main/java/com/massivecraft/factions/tag/FactionTag.java
@@ -149,10 +149,7 @@ public enum FactionTag implements Tag {
         if (!this.foundInString(text)) {
             return text;
         }
-        String result = null;
-        if (this.biFunction != null) {
-            result = this.function == null ? this.biFunction.apply(faction, player) : this.function.apply(faction);
-        }
+        String result = this.function == null ? this.biFunction.apply(faction, player) : this.function.apply(faction);
         return result == null ? null : text.replace(this.tag, result);
     }
 

--- a/src/main/java/com/massivecraft/factions/tag/PlayerTag.java
+++ b/src/main/java/com/massivecraft/factions/tag/PlayerTag.java
@@ -21,6 +21,7 @@ public enum PlayerTag implements Tag {
     }),
     PLAYER_BALANCE("{balance}", (fp) -> Econ.isSetup() ? Econ.getFriendlyBalance(fp) : (Tag.isMinimalShow() ? null : TL.ECON_OFF.format("balance"))),
     PLAYER_POWER("{player-power}", (fp) -> String.valueOf(fp.getPowerRounded())),
+    ROLE("{player-role}", FPlayer::getRolePrefix),
     PLAYER_MAXPOWER("{player-maxpower}", (fp) -> String.valueOf(fp.getPowerMaxRounded())),
     PLAYER_KILLS("{player-kills}", (fp) -> String.valueOf(fp.getKills())),
     PLAYER_DEATHS("{player-deaths}", (fp) -> String.valueOf(fp.getDeaths())),


### PR DESCRIPTION
Fixed an error that appears when a player uses /f wild after interrupting a previous wild teleport request.
Fixed an error that appears when a player uses /f wild while the countdown before teleportation is in progress.