### PR TITLE
Apply missing &r tags on FACTION_LEAVE TL

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -1272,7 +1272,7 @@ public enum TL {
     SAFEZONE("safezone", "&6Safezone"),
     SAFEZONE_DESCRIPTION("safezone-description", "Free from pvp and monsters."),
     TOGGLE_SB("toggle-sb", "You now have scoreboards set to {value}"),
-    FACTION_LEAVE("faction-leave", "Leaving %1$s, Entering %2$s"),
+    FACTION_LEAVE("faction-leave", "Leaving %1$s&r, Entering %2$s&r"),
     FACTIONS_ANNOUNCEMENT_TOP("faction-announcement-top", "&d--Unread Faction Announcements--"),
     FACTIONS_ANNOUNCEMENT_BOTTOM("faction-announcement-bottom", "&d--Unread Faction Announcements--"),
     DEFAULT_PREFIX("default-prefix", "{relationcolor}[{faction}]"),


### PR DESCRIPTION
This is a minor change, do check the actual formatting as I am unsure where this TL is used and as such am unsure how the color code for the faction name is implemented.

(Right now, the ", Entering" substring is displayed in the color of the left faction's name as demonstrated with the image below.)
![image](https://user-images.githubusercontent.com/19798667/88453175-ff177400-ce64-11ea-8704-463fff48c7c0.png)