### PR TITLE
Update JDA from deprecated 3.x to latest build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 SaberFactions is an exotic, performance optimized, and feature rich factions plugin that focuses on not only making the player experience as great as possibly but maintaining this aspect with the cost of NOTHING! We strive to continue development for SaberFactions as the factions community is strongly growing and seeking new players every day. 
 
-<right>
+<left>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/KHX4SwR.png"></a>
-</right>
+</left>
 
 Some of our features include the following 
 
@@ -26,9 +26,9 @@ Some of our features include the following
 * Factions Check System - An automated check system that alerts players when to check walls/buffers!
 * Faction Reserves - A system designed to reserve a specific faction name for a specific player!
 
-<right>
+<left>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/cL8vejT.png"></a>
-</right>
+</left>
 
 ```	
 	<repositories>
@@ -44,16 +44,16 @@ Some of our features include the following
 	    <version>2.3.3-STABLE</version>
 	</dependency>
 ```
-<right>
+<left>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/Nye6EuK.png"></a>
-</right>
+</left>
 
 Moving forward we plan to take all suggestions into consideration, as they come from our community. 
 We Plan on Releasing the latest and greatest factions/skyblock/prison plugins minecraft has to offer and wont settle for anything less
 
-<right>
+<left>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/CyshdE9.png"></a>
-</right>
+</left>
 
 Have a problem, question, or concer? We encourage our community to join and express any inquiry you may have
 https://discord.saber.pw

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <center>
-  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/0Qf8N2V.png"></a>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/HMgdPGP.png"></a>
 </center>
 
 ![Downloads](https://img.shields.io/github/downloads/driftay/saber-factions/total.svg) [![CodeFactor](https://www.codefactor.io/repository/github/driftay/saber-factions/badge)](https://www.codefactor.io/repository/github/driftay/saber-factions) [![License](https://img.shields.io/badge/license-GNU%20General%20Public%20License%20v3.0-brightgreen)](https://github.com/SaberLLC/Saber-Factions/blob/1.6.x/LICENSE) ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/SaberLLC/Saber-Factions) [![](https://jitpack.io/v/SaberLLC/Saber-Factions.svg)](https://jitpack.io/#SaberLLC/Saber-Factions)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 SaberFactions is an exotic, performance optimized, and feature rich factions plugin that focuses on not only making the player experience as great as possibly but maintaining this aspect with the cost of NOTHING! We strive to continue development for SaberFactions as the factions community is strongly growing and seeking new players every day. 
 
-## Some Exciting Features
+<right>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/KHX4SwR.png"></a>
+</right>
 Some of our features include the following 
 
 * Factions Grace Period - Deny Raiding Between Factions Temporarily
@@ -23,7 +25,9 @@ Some of our features include the following
 * Factions Check System - An automated check system that alerts players when to check walls/buffers!
 * Faction Reserves - A system designed to reserve a specific faction name for a specific player!
 
-## Dependency With Maven
+<right>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/cL8vejT.png"></a>
+</right>
 ```	
 	<repositories>
 		<repository>
@@ -38,12 +42,15 @@ Some of our features include the following
 	    <version>2.3.3-STABLE</version>
 	</dependency>
 ```
-## Moving Forward
-
+<right>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/Nye6EuK.png"></a>
+</right>
 Moving forward we plan to take all suggestions into consideration, as they come from our community. 
 We Plan on Releasing the latest and greatest factions/skyblock/prison plugins minecraft has to offer and wont settle for anything less
 
-## Support
+<right>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/CyshdE9.png"></a>
+</right>
 Have a problem, question, or concer? We encourage our community to join and express any inquiry you may have
 https://discord.saber.pw
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SaberFactions
+<center>
+  <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/0Qf8N2V.png"></a>
+</center>
 
 ![Downloads](https://img.shields.io/github/downloads/driftay/saber-factions/total.svg) [![CodeFactor](https://www.codefactor.io/repository/github/driftay/saber-factions/badge)](https://www.codefactor.io/repository/github/driftay/saber-factions) [![License](https://img.shields.io/badge/license-GNU%20General%20Public%20License%20v3.0-brightgreen)](https://github.com/SaberLLC/Saber-Factions/blob/1.6.x/LICENSE) ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/SaberLLC/Saber-Factions) [![](https://jitpack.io/v/SaberLLC/Saber-Factions.svg)](https://jitpack.io/#SaberLLC/Saber-Factions)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Some of our features include the following
 * Faction Audit - A full based logging system (GUI designed) to see every aspect of what happens in your faction!
 * Factions Check System - An automated check system that alerts players when to check walls/buffers!
 * Faction Reserves - A system designed to reserve a specific faction name for a specific player!
+* Faction Invsee - Allow Faction Members to see each others inventories!
+* Factions Missions - Quest based system to allow players to do missions for in-game rewards!
 
 <left>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/cL8vejT.png"></a>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SaberFactions is an exotic, performance optimized, and feature rich factions plu
 <right>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/KHX4SwR.png"></a>
 </right>
+
 Some of our features include the following 
 
 * Factions Grace Period - Deny Raiding Between Factions Temporarily
@@ -28,6 +29,7 @@ Some of our features include the following
 <right>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/cL8vejT.png"></a>
 </right>
+
 ```	
 	<repositories>
 		<repository>
@@ -45,12 +47,14 @@ Some of our features include the following
 <right>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/Nye6EuK.png"></a>
 </right>
+
 Moving forward we plan to take all suggestions into consideration, as they come from our community. 
 We Plan on Releasing the latest and greatest factions/skyblock/prison plugins minecraft has to offer and wont settle for anything less
 
 <right>
   <a href="https://www.spigotmc.org/resources/saberfactions-1-8-1-15-the-complete-factions-solution.69771/"><img src="https://i.imgur.com/CyshdE9.png"></a>
 </right>
+
 Have a problem, question, or concer? We encourage our community to join and express any inquiry you may have
 https://discord.saber.pw
 

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>3.8.3_463</version>
+            <version>4.2.0_214</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.massivecraft</groupId>
     <artifactId>Factions</artifactId>
-    <version>1.6.9.5-2.3.9-RC</version>
+    <version>1.6.9.5-2.3.10-RC</version>
     <packaging>jar</packaging>
 
     <name>SaberFactions</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.massivecraft</groupId>
     <artifactId>Factions</artifactId>
-    <version>1.6.9.5-2.3.10-RC</version>
+    <version>1.6.9.5-2.4.1-RC</version>
     <packaging>jar</packaging>
 
     <name>SaberFactions</name>

--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -577,7 +577,7 @@ public class Conf {
         safeZoneNerfedCreatureTypes.add(EntityType.ENDERMAN);
         safeZoneNerfedCreatureTypes.add(EntityType.GHAST);
         safeZoneNerfedCreatureTypes.add(EntityType.MAGMA_CUBE);
-        safeZoneNerfedCreatureTypes.add(EntityType.PIG_ZOMBIE);
+        if (!FactionsPlugin.getInstance().mc116) safeZoneNerfedCreatureTypes.add(EntityType.PIG_ZOMBIE);
         safeZoneNerfedCreatureTypes.add(EntityType.SILVERFISH);
         safeZoneNerfedCreatureTypes.add(EntityType.SKELETON);
         safeZoneNerfedCreatureTypes.add(EntityType.SPIDER);

--- a/src/main/java/com/massivecraft/factions/FactionsPlugin.java
+++ b/src/main/java/com/massivecraft/factions/FactionsPlugin.java
@@ -81,6 +81,7 @@ public class FactionsPlugin extends MPlugin {
     public boolean mc113 = false;
     public boolean mc114 = false;
     public boolean mc115 = false;
+    public boolean mc116 = false;
     public boolean useNonPacketParticles = false;
     public List<String> itemList = getConfig().getStringList("fchest.Items-Not-Allowed");
     SkriptAddon skriptAddon;
@@ -166,6 +167,10 @@ public class FactionsPlugin extends MPlugin {
             case 15:
                 FactionsPlugin.instance.log("Minecraft Version 1.15 found.");
                 mc115 = true;
+                break;
+            case 16:
+                FactionsPlugin.instance.log("Minecraft Version 1.16 found.");
+                mc116 = true;
                 break;
         }
         migrateFPlayerLeaders();

--- a/src/main/java/com/massivecraft/factions/util/XMaterial.java
+++ b/src/main/java/com/massivecraft/factions/util/XMaterial.java
@@ -1,5 +1,4 @@
 package com.massivecraft.factions.util;
-
 /*
  * The MIT License (MIT)
  *
@@ -42,30 +41,23 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-/*
- * References
- *
- * * * GitHub: https://github.com/CryptoMorin/XSeries/blob/master/XMaterial.java
- * * XSeries: https://www.spigotmc.org/threads/378136/
+/**
+ * <b>XMaterial</b> - Data Values/Pre-flattening<br>
+ * 1.13 and above as priority.
+ * <p>
+ * This class is mainly designed to support ItemStacks.
+ * If you want to use it on blocks you'll have to
+ * use <a href="https://github.com/CryptoMorin/XSeries/blob/master/XBlock.java">XBlock</a>
+ * <p>
  * Pre-flattening: https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening
  * Materials: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
  * Materials (1.12): https://helpch.at/docs/1.12.2/index.html?org/bukkit/Material.html
  * Material IDs: https://minecraft-ids.grahamedgecombe.com/
  * Material Source Code: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/Material.java
  * XMaterial v1: https://www.spigotmc.org/threads/329630/
- */
-
-/**
- * <b>XMaterial</b> - Data Values/Pre-flattening<br>
- * Supports 1.8-1.15<br>
- * 1.13 and above as priority.
- * <p>
- * This class is mainly designed to support ItemStacks.
- * If you want to use it on blocks you'll have to
- * use <a href="https://github.com/CryptoMorin/XSeries/blob/master/XBlock.java">XBlock</a>
  *
  * @author Crypto Morin
- * @version 4.0.0
+ * @version 5.0.0
  * @see Material
  * @see ItemStack
  */
@@ -96,6 +88,7 @@ public enum XMaterial {
      */
     AIR,
     ALLIUM(2, "RED_ROSE"),
+    ANCIENT_DEBRIS("1.16"),
     ANDESITE(5, "STONE"),
     ANDESITE_SLAB,
     ANDESITE_STAIRS,
@@ -112,6 +105,7 @@ public enum XMaterial {
     BAMBOO_SAPLING("1.14"),
     BARREL("1.14", "CHEST", ""),
     BARRIER,
+    BASALT("1.16"),
     BAT_SPAWN_EGG(65, "MONSTER_EGG"),
     BEACON,
     BEDROCK,
@@ -144,8 +138,12 @@ public enum XMaterial {
     BIRCH_TRAPDOOR("TRAP_DOOR"),
     BIRCH_WALL_SIGN("SIGN_POST", "WALL_SIGN"),
     BIRCH_WOOD(2, "LOG"),
+    BLACKSTONE("1.16"),
+    BLACKSTONE_SLAB("1.16"),
+    BLACKSTONE_STAIRS("1.16"),
+    BLACKSTONE_WALL("1.16"),
     BLACK_BANNER("BANNER", "STANDING_BANNER"),
-    BLACK_BED(15, "BED", "BED_BLOCK"),
+    BLACK_BED(15, "BED_BLOCK", "BED"),
     BLACK_CARPET(15, "CARPET"),
     BLACK_CONCRETE(15, "CONCRETE"),
     BLACK_CONCRETE_POWDER(15, "CONCRETE_POWDER"),
@@ -161,8 +159,8 @@ public enum XMaterial {
     BLAZE_POWDER,
     BLAZE_ROD,
     BLAZE_SPAWN_EGG(61, "MONSTER_EGG"),
-    BLUE_BANNER(11, "BANNER", "STANDING_BANNER"),
-    BLUE_BED(4, "BED", "BED_BLOCK"),
+    BLUE_BANNER(4, "BANNER", "STANDING_BANNER"),
+    BLUE_BED(11, "BED_BLOCK", "BED"),
     BLUE_CARPET(11, "CARPET"),
     BLUE_CONCRETE(11, "CONCRETE"),
     BLUE_CONCRETE_POWDER(11, "CONCRETE_POWDER"),
@@ -173,8 +171,8 @@ public enum XMaterial {
     BLUE_SHULKER_BOX,
     BLUE_STAINED_GLASS(11, "STAINED_GLASS"),
     BLUE_STAINED_GLASS_PANE(11, "THIN_GLASS", "STAINED_GLASS_PANE"),
-    BLUE_TERRACOTTA(11, "STAINED_CLAY"),
-    BLUE_WALL_BANNER(11, "WALL_BANNER"),
+    BLUE_TERRACOTTA(11, "HARD_CLAY", "STAINED_CLAY"),
+    BLUE_WALL_BANNER(4, "WALL_BANNER"),
     BLUE_WOOL(11, "WOOL"),
     BONE,
     BONE_BLOCK,
@@ -195,7 +193,7 @@ public enum XMaterial {
     BRICK_STAIRS,
     BRICK_WALL,
     BROWN_BANNER(3, "BANNER", "STANDING_BANNER"),
-    BROWN_BED(12, "BED", "BED_BLOCK"),
+    BROWN_BED(12, "BED_BLOCK", "BED"),
     BROWN_CARPET(12, "CARPET"),
     BROWN_CONCRETE(12, "CONCRETE"),
     BROWN_CONCRETE_POWDER(12, "CONCRETE_POWDER"),
@@ -232,6 +230,7 @@ public enum XMaterial {
      */
     CAVE_AIR("AIR"),
     CAVE_SPIDER_SPAWN_EGG(59, "MONSTER_EGG"),
+    CHAIN("1.16"),
     CHAINMAIL_BOOTS,
     CHAINMAIL_CHESTPLATE,
     CHAINMAIL_HELMET,
@@ -243,6 +242,8 @@ public enum XMaterial {
     CHICKEN("RAW_CHICKEN"),
     CHICKEN_SPAWN_EGG(93, "MONSTER_EGG"),
     CHIPPED_ANVIL(1, "ANVIL"),
+    CHISELED_NETHER_BRICKS(1, "NETHER_BRICKS"),
+    CHISELED_POLISHED_BLACKSTONE("1.16", "POLISHED_BLACKSTONE"),
     CHISELED_QUARTZ_BLOCK(1, "QUARTZ_BLOCK"),
     CHISELED_RED_SANDSTONE(1, "RED_SANDSTONE"),
     CHISELED_SANDSTONE(1, "SANDSTONE"),
@@ -269,7 +270,14 @@ public enum XMaterial {
     COD_SPAWN_EGG("1.13", "MONSTER_EGG", ""),
     COMMAND_BLOCK("COMMAND"),
     COMMAND_BLOCK_MINECART("COMMAND_MINECART"),
-    COMPARATOR("REDSTONE_COMPARATOR", "REDSTONE_COMPARATOR_ON", "REDSTONE_COMPARATOR_OFF"),
+    /**
+     * Unlike redstone torch and redstone lamp... neither REDTONE_COMPARATOR_OFF nor REDSTONE_COMPARATOR_ON
+     * are items. REDSTONE_COMPARATOR is.
+     *
+     * @see #REDSTONE_TORCH
+     * @see #REDSTONE_LAMP
+     */
+    COMPARATOR("REDSTONE_COMPARATOR_OFF", "REDSTONE_COMPARATOR_ON", "REDSTONE_COMPARATOR"),
     COMPASS,
     COMPOSTER("1.14", "CAULDRON", ""),
     CONDUIT("1.13", "BEACON"),
@@ -283,19 +291,38 @@ public enum XMaterial {
     COOKIE,
     CORNFLOWER(4, "1.14", "BLUE_DYE", ""),
     COW_SPAWN_EGG(92, "MONSTER_EGG"),
+    CRACKED_NETHER_BRICKS(2, "NETHER_BRICKS"),
+    CRACKED_POLISHED_BLACKSTONE_BRICKS("1.16", "POLISHED_BLACKSTONE_BRICKS"),
     CRACKED_STONE_BRICKS(2, "SMOOTH_BRICK"),
     CRAFTING_TABLE("WORKBENCH"),
     CREEPER_BANNER_PATTERN,
     CREEPER_HEAD(4, "SKULL", "SKULL_ITEM"),
     CREEPER_SPAWN_EGG(50, "MONSTER_EGG"),
     CREEPER_WALL_HEAD(4, "SKULL", "SKULL_ITEM"),
+    CRIMSON_BUTTON("1.16"),
+    CRIMSON_DOOR("1.16"),
+    CRIMSON_FENCE("1.16"),
+    CRIMSON_FENCE_GATE("1.16"),
+    CRIMSON_FUNGUS("1.16"),
+    CRIMSON_HYPHAE("1.16"),
+    CRIMSON_NYLIUM("1.16"),
+    CRIMSON_PLANKS("1.16"),
+    CRIMSON_PRESSURE_PLATE("1.16"),
+    CRIMSON_ROOTS("1.16"),
+    CRIMSON_SIGN("1.16"),
+    CRIMSON_SLAB("1.16"),
+    CRIMSON_STAIRS("1.16"),
+    CRIMSON_STEM("1.16"),
+    CRIMSON_TRAPDOOR("1.16"),
+    CRIMSON_WALL_SIGN("1.16"),
     CROSSBOW,
+    CRYING_OBSIDIAN("1.16"),
     CUT_RED_SANDSTONE("1.13"),
     CUT_RED_SANDSTONE_SLAB("STONE_SLAB2"),
     CUT_SANDSTONE("1.13"),
     CUT_SANDSTONE_SLAB("STEP"),
     CYAN_BANNER(6, "BANNER", "STANDING_BANNER"),
-    CYAN_BED(9, "BED", "BED_BLOCK"),
+    CYAN_BED(9, "BED_BLOCK", "BED"),
     CYAN_CARPET(9, "CARPET"),
     CYAN_CONCRETE(9, "CONCRETE"),
     CYAN_CONCRETE_POWDER(9, "CONCRETE_POWDER"),
@@ -314,13 +341,13 @@ public enum XMaterial {
     DARK_OAK_DOOR("DARK_OAK_DOOR_ITEM"),
     DARK_OAK_FENCE,
     DARK_OAK_FENCE_GATE,
-    DARK_OAK_LEAVES(1, "LEAVES", "LEAVES_2"),
+    DARK_OAK_LEAVES(4, "LEAVES", "LEAVES_2"),
     DARK_OAK_LOG(1, "LOG", "LOG_2"),
     DARK_OAK_PLANKS(5, "WOOD"),
     DARK_OAK_PRESSURE_PLATE("WOOD_PLATE"),
     DARK_OAK_SAPLING(5, "SAPLING"),
     DARK_OAK_SIGN("SIGN"),
-    DARK_OAK_SLAB("WOOD_STEP", "WOODEN_SLAB", "WOOD_DOUBLE_STEP"),
+    DARK_OAK_SLAB(5, "WOOD_STEP", "WOODEN_SLAB", "WOOD_DOUBLE_STEP"),
     DARK_OAK_STAIRS,
     DARK_OAK_TRAPDOOR("TRAP_DOOR"),
     DARK_OAK_WALL_SIGN("SIGN_POST", "WALL_SIGN"),
@@ -402,7 +429,7 @@ public enum XMaterial {
     END_ROD("1.9", "BLAZE_ROD", ""),
     END_STONE("ENDER_STONE"),
     END_STONE_BRICKS("END_BRICKS"),
-    END_STONE_BRICK_SLAB(4, "STEP"),
+    END_STONE_BRICK_SLAB(6, "STEP"),
     END_STONE_BRICK_STAIRS("SMOOTH_STAIRS"),
     END_STONE_BRICK_WALL,
     EVOKER_SPAWN_EGG(34, "MONSTER_EGG"),
@@ -410,7 +437,12 @@ public enum XMaterial {
     FARMLAND("SOIL"),
     FEATHER,
     FERMENTED_SPIDER_EYE,
-    FERN(2, "LONG_GRASS"),
+    FERN(1, "LONG_GRASS"),
+    /**
+     * For some reasons filled map items are really special.
+     * Their data value starts from 0 and every time a player
+     * creates a new map that maps data value increases.
+     */
     FILLED_MAP("MAP"),
     FIRE,
     FIREWORK_ROCKET("FIREWORK"),
@@ -467,7 +499,7 @@ public enum XMaterial {
     GRASS_PATH,
     GRAVEL,
     GRAY_BANNER(8, "BANNER", "STANDING_BANNER"),
-    GRAY_BED(7, "BED", "BED_BLOCK"),
+    GRAY_BED(7, "BED_BLOCK", "BED"),
     GRAY_CARPET(7, "CARPET"),
     GRAY_CONCRETE(7, "CONCRETE"),
     GRAY_CONCRETE_POWDER(7, "CONCRETE_POWDER"),
@@ -480,7 +512,7 @@ public enum XMaterial {
     GRAY_WALL_BANNER(8, "WALL_BANNER"),
     GRAY_WOOL(7, "WOOL"),
     GREEN_BANNER(2, "BANNER", "STANDING_BANNER"),
-    GREEN_BED(13, "BED", "BED_BLOCK"),
+    GREEN_BED(13, "BED_BLOCK", "BED"),
     GREEN_CARPET(13, "CARPET"),
     GREEN_CONCRETE(13, "CONCRETE"),
     GREEN_CONCRETE_POWDER(13, "CONCRETE_POWDER"),
@@ -498,6 +530,7 @@ public enum XMaterial {
     HAY_BLOCK,
     HEART_OF_THE_SEA("1.13"),
     HEAVY_WEIGHTED_PRESSURE_PLATE("IRON_PLATE"),
+    HOGLIN_SPAWN_EGG("1.16", "MONSTER_EGG"),
     HONEYCOMB("1.15"),
     HONEYCOMB_BLOCK("1.15"),
     HONEY_BLOCK("1.15", "SLIME_BLOCK", ""),
@@ -575,8 +608,8 @@ public enum XMaterial {
     LEATHER_LEGGINGS,
     LECTERN("1.14", "BOOKSHELF", ""),
     LEVER,
-    LIGHT_BLUE_BANNER(3, "BANNER", "STANDING_BANNER"),
-    LIGHT_BLUE_BED(3, "BED", "BED_BLOCK"),
+    LIGHT_BLUE_BANNER(12, "BANNER", "STANDING_BANNER"),
+    LIGHT_BLUE_BED(3, "BED_BLOCK", "BED"),
     LIGHT_BLUE_CARPET(3, "CARPET"),
     LIGHT_BLUE_CONCRETE(3, "CONCRETE"),
     LIGHT_BLUE_CONCRETE_POWDER(3, "CONCRETE_POWDER"),
@@ -589,16 +622,16 @@ public enum XMaterial {
     LIGHT_BLUE_WALL_BANNER(12, "WALL_BANNER", "BANNER", "STANDING_BANNER"),
     LIGHT_BLUE_WOOL(3, "WOOL"),
     LIGHT_GRAY_BANNER(7, "BANNER", "STANDING_BANNER"),
-    LIGHT_GRAY_BED(8, "BED", "BED_BLOCK"),
+    LIGHT_GRAY_BED(8, "BED_BLOCK", "BED"),
     LIGHT_GRAY_CARPET(8, "CARPET"),
     LIGHT_GRAY_CONCRETE(8, "CONCRETE"),
     LIGHT_GRAY_CONCRETE_POWDER(8, "CONCRETE_POWDER"),
     LIGHT_GRAY_DYE(7, "INK_SACK"),
     /**
-     * Renamed to SILVER_GLAZED_TERRACOTTA in 1.13
+     * Renamed to SILVER_GLAZED_TERRACOTTA in 1.12
      * Renamed to LIGHT_GRAY_GLAZED_TERRACOTTA in 1.14
      */
-    LIGHT_GRAY_GLAZED_TERRACOTTA(8, "1.12", "HARD_CLAY", "STAINED_CLAY", "LIGHT_GRAY_TERRACOTTA", "SILVER_GLAZED_TERRACOTTA"),
+    LIGHT_GRAY_GLAZED_TERRACOTTA("1.12", "HARD_CLAY", "STAINED_CLAY", "LIGHT_GRAY_TERRACOTTA", "SILVER_GLAZED_TERRACOTTA"),
     LIGHT_GRAY_SHULKER_BOX("SILVER_SHULKER_BOX"),
     LIGHT_GRAY_STAINED_GLASS(8, "STAINED_GLASS"),
     LIGHT_GRAY_STAINED_GLASS_PANE(8, "THIN_GLASS", "STAINED_GLASS_PANE"),
@@ -610,7 +643,7 @@ public enum XMaterial {
     LILY_OF_THE_VALLEY(15, "1.14", "WHITE_DYE", ""),
     LILY_PAD("WATER_LILY"),
     LIME_BANNER(10, "BANNER", "STANDING_BANNER"),
-    LIME_BED(5, "BED", "BED_BLOCK"),
+    LIME_BED(5, "BED_BLOCK", "BED"),
     LIME_CARPET(5, "CARPET"),
     LIME_CONCRETE(5, "CONCRETE"),
     LIME_CONCRETE_POWDER(5, "CONCRETE_POWDER"),
@@ -624,9 +657,10 @@ public enum XMaterial {
     LIME_WOOL(5, "WOOL"),
     LINGERING_POTION,
     LLAMA_SPAWN_EGG(103, "MONSTER_EGG"),
+    LODESTONE("1.16"),
     LOOM("1.14"),
     MAGENTA_BANNER(13, "BANNER", "STANDING_BANNER"),
-    MAGENTA_BED(2, "BED", "BED_BLOCK"),
+    MAGENTA_BED(2, "BED_BLOCK", "BED"),
     MAGENTA_CARPET(2, "CARPET"),
     MAGENTA_CONCRETE(2, "CONCRETE"),
     MAGENTA_CONCRETE_POWDER(2, "CONCRETE_POWDER"),
@@ -641,6 +675,13 @@ public enum XMaterial {
     MAGMA_BLOCK("1.10", "MAGMA"),
     MAGMA_CREAM,
     MAGMA_CUBE_SPAWN_EGG(62, "MONSTER_EGG"),
+    /**
+     * Adding this to the duplicated list will give you a filled map
+     * for 1.13+ versions and removing it from duplicated list will
+     * still give you a filled map in -1.12 versions.
+     * Since higher versions are our priority I'll keep 1.13+ support
+     * until I can come up with something to fix it.
+     */
     MAP("EMPTY_MAP"),
     MELON("MELON_BLOCK"),
     MELON_SEEDS,
@@ -655,7 +696,7 @@ public enum XMaterial {
     MOSSY_COBBLESTONE_STAIRS,
     MOSSY_COBBLESTONE_WALL(1, "COBBLE_WALL", "COBBLESTONE_WALL"),
     MOSSY_STONE_BRICKS(1, "SMOOTH_BRICK"),
-    MOSSY_STONE_BRICK_SLAB(4, "STEP"),
+    MOSSY_STONE_BRICK_SLAB(5, "STEP"),
     MOSSY_STONE_BRICK_STAIRS("SMOOTH_STAIRS"),
     MOSSY_STONE_BRICK_WALL,
     MOVING_PISTON("PISTON_BASE", "PISTON_MOVING_PIECE"),
@@ -678,15 +719,29 @@ public enum XMaterial {
     MYCELIUM("MYCEL"),
     NAME_TAG,
     NAUTILUS_SHELL("1.13"),
+    NETHERITE_AXE("1.16"),
+    NETHERITE_BLOCK("1.16"),
+    NETHERITE_BOOTS("1.16"),
+    NETHERITE_CHESTPLATE("1.16"),
+    NETHERITE_HELMET("1.16"),
+    NETHERITE_HOE("1.16"),
+    NETHERITE_INGOT("1.16"),
+    NETHERITE_LEGGINGS("1.16"),
+    NETHERITE_PICKAXE("1.16"),
+    NETHERITE_SCRAP("1.16"),
+    NETHERITE_SHOVEL("1.16"),
+    NETHERITE_SWORD("1.16"),
     NETHERRACK,
     NETHER_BRICK("NETHER_BRICK_ITEM"),
     NETHER_BRICKS("NETHER_BRICK"),
     NETHER_BRICK_FENCE("NETHER_FENCE"),
-    NETHER_BRICK_SLAB(4, "STEP"),
+    NETHER_BRICK_SLAB(6, "STEP"),
     NETHER_BRICK_STAIRS,
     NETHER_BRICK_WALL,
+    NETHER_GOLD_ORE("1.16"),
     NETHER_PORTAL("PORTAL"),
     NETHER_QUARTZ_ORE("QUARTZ_ORE"),
+    NETHER_SPROUTS("1.16"),
     NETHER_STAR,
     /**
      * Just like mentioned in https://minecraft.gamepedia.com/Nether_Wart
@@ -716,7 +771,7 @@ public enum XMaterial {
     OBSIDIAN,
     OCELOT_SPAWN_EGG(98, "MONSTER_EGG"),
     ORANGE_BANNER(14, "BANNER", "STANDING_BANNER"),
-    ORANGE_BED(1, "BED", "BED_BLOCK"),
+    ORANGE_BED(1, "BED_BLOCK", "BED"),
     ORANGE_CARPET(1, "CARPET"),
     ORANGE_CONCRETE(1, "CONCRETE"),
     ORANGE_CONCRETE_POWDER(1, "CONCRETE_POWDER"),
@@ -742,7 +797,7 @@ public enum XMaterial {
     PIG_SPAWN_EGG(90, "MONSTER_EGG"),
     PILLAGER_SPAWN_EGG("1.14"),
     PINK_BANNER(9, "BANNER", "STANDING_BANNER"),
-    PINK_BED(6, "BED", "BED_BLOCK"),
+    PINK_BED(6, "BED_BLOCK", "BED"),
     PINK_CARPET(6, "CARPET"),
     PINK_CONCRETE(6, "CONCRETE"),
     PINK_CONCRETE_POWDER(6, "CONCRETE_POWDER"),
@@ -753,7 +808,7 @@ public enum XMaterial {
     PINK_STAINED_GLASS_PANE(6, "THIN_GLASS", "STAINED_GLASS_PANE"),
     PINK_TERRACOTTA(6, "HARD_CLAY", "STAINED_CLAY"),
     PINK_TULIP(7, "RED_ROSE"),
-    PINK_WALL_BANNER(14, "WALL_BANNER"),
+    PINK_WALL_BANNER(9, "WALL_BANNER"),
     PINK_WOOL(6, "WOOL"),
     PISTON("PISTON_BASE"),
     PISTON_HEAD("PISTON_EXTENSION"),
@@ -765,6 +820,17 @@ public enum XMaterial {
     POLISHED_ANDESITE(6, "STONE"),
     POLISHED_ANDESITE_SLAB,
     POLISHED_ANDESITE_STAIRS,
+    POLISHED_BASALT("1.16"),
+    POLISHED_BLACKSTONE("1.16"),
+    POLISHED_BLACKSTONE_BRICKS("1.16"),
+    POLISHED_BLACKSTONE_BRICK_SLAB("1.16"),
+    POLISHED_BLACKSTONE_BRICK_STAIRS("1.16"),
+    POLISHED_BLACKSTONE_BRICK_WALL("1.16"),
+    POLISHED_BLACKSTONE_BUTTON("1.16"),
+    POLISHED_BLACKSTONE_PRESSURE_PLATE("1.16"),
+    POLISHED_BLACKSTONE_SLAB("1.16"),
+    POLISHED_BLACKSTONE_STAIRS("1.16"),
+    POLISHED_BLACKSTONE_WALL("1.16"),
     POLISHED_DIORITE(4, "STONE"),
     POLISHED_DIORITE_SLAB,
     POLISHED_DIORITE_STAIRS,
@@ -820,7 +886,7 @@ public enum XMaterial {
     PUMPKIN_SEEDS,
     PUMPKIN_STEM,
     PURPLE_BANNER(5, "BANNER", "STANDING_BANNER"),
-    PURPLE_BED(10, "BED", "BED_BLOCK"),
+    PURPLE_BED(10, "BED_BLOCK", "BED"),
     PURPLE_CARPET(10, "CARPET"),
     PURPLE_CONCRETE(10, "CONCRETE"),
     PURPLE_CONCRETE_POWDER(10, "CONCRETE_POWDER"),
@@ -850,17 +916,34 @@ public enum XMaterial {
     RAVAGER_SPAWN_EGG("1.14"),
     REDSTONE,
     REDSTONE_BLOCK,
-    REDSTONE_LAMP("REDSTONE_LAMP_OFF", "REDSTONE_LAMP_ON"),
+    /**
+     * Unlike redstone torch, REDSTONE_LAMP_ON isn't an item.
+     * The name is just here on the list for matching.
+     *
+     * @see #REDSTONE_TORCH
+     */
+    REDSTONE_LAMP("REDSTONE_LAMP_ON", "REDSTONE_LAMP_OFF"),
     REDSTONE_ORE("GLOWING_REDSTONE_ORE"),
-    REDSTONE_TORCH("REDSTONE_TORCH_ON", "REDSTONE_TORCH_OFF"),
-    REDSTONE_WALL_TORCH(1, "REDSTONE_TORCH_ON", "REDSTONE_TORCH_OFF"),
+    /**
+     * REDSTONE_TORCH_OFF isn't an item, but a block.
+     * But REDSTONE_TORCH_ON is the item.
+     * The name is just here on the list for matching.
+     */
+    REDSTONE_TORCH("REDSTONE_TORCH_OFF", "REDSTONE_TORCH_ON"),
+    REDSTONE_WALL_TORCH,
     REDSTONE_WIRE,
     RED_BANNER(1, "BANNER", "STANDING_BANNER"),
-    RED_BED(14, "BED", "BED_BLOCK"),
+    /**
+     * Data value 14 or 0
+     */
+    RED_BED(0, "BED_BLOCK", "BED"),
     RED_CARPET(14, "CARPET"),
     RED_CONCRETE(14, "CONCRETE"),
     RED_CONCRETE_POWDER(14, "CONCRETE_POWDER"),
-    RED_DYE(1, "ROSE_RED"),
+    /**
+     * Data value 0 or 1?
+     */
+    RED_DYE(0, "INK_SACK", "ROSE_RED"),
     RED_GLAZED_TERRACOTTA(14, "1.12", "HARD_CLAY", "STAINED_CLAY", "RED_TERRACOTTA"),
     RED_MUSHROOM,
     RED_MUSHROOM_BLOCK("RED_MUSHROOM", "HUGE_MUSHROOM_2"),
@@ -882,6 +965,7 @@ public enum XMaterial {
     RED_WOOL(14, "WOOL"),
     REPEATER("DIODE", "DIODE_BLOCK_ON", "DIODE_BLOCK_OFF"),
     REPEATING_COMMAND_BLOCK("COMMAND", "COMMAND_REPEATING"),
+    RESPAWN_ANCHOR("1.16"),
     ROSE_BUSH(4, "DOUBLE_PLANT"),
     ROTTEN_FLESH,
     SADDLE,
@@ -901,6 +985,7 @@ public enum XMaterial {
     SHEARS,
     SHEEP_SPAWN_EGG(91, "MONSTER_EGG"),
     SHIELD,
+    SHROOMLIGHT("1.16"),
     SHULKER_BOX("PURPLE_SHULKER_BOX"),
     SHULKER_SHELL,
     SHULKER_SPAWN_EGG(69, "MONSTER_EGG"),
@@ -929,7 +1014,13 @@ public enum XMaterial {
     SNOW,
     SNOWBALL("SNOW_BALL"),
     SNOW_BLOCK,
+    SOUL_CAMPFIRE("1.16"),
+    SOUL_FIRE("1.16"),
+    SOUL_LANTERN("1.16"),
     SOUL_SAND,
+    SOUL_SOIL("1.16"),
+    SOUL_TORCH("1.16"),
+    SOUL_WALL_TORCH("1.16"),
     SPAWNER("MOB_SPAWNER"),
     SPECTRAL_ARROW("1.9", "ARROW", ""),
     SPIDER_EYE,
@@ -976,6 +1067,8 @@ public enum XMaterial {
     STRIPPED_ACACIA_WOOD("LOG_2"),
     STRIPPED_BIRCH_LOG(2, "LOG"),
     STRIPPED_BIRCH_WOOD(2, "LOG"),
+    STRIPPED_CRIMSON_HYPHAE("1.16"),
+    STRIPPED_CRIMSON_STEM("1.16"),
     STRIPPED_DARK_OAK_LOG("LOG"),
     STRIPPED_DARK_OAK_WOOD("LOG"),
     STRIPPED_JUNGLE_LOG(3, "LOG"),
@@ -984,6 +1077,8 @@ public enum XMaterial {
     STRIPPED_OAK_WOOD("LOG"),
     STRIPPED_SPRUCE_LOG(1, "LOG"),
     STRIPPED_SPRUCE_WOOD(1, "LOG"),
+    STRIPPED_WARPED_HYPHAE("1.16"),
+    STRIPPED_WARPED_STEM("1.16"),
     STRUCTURE_BLOCK,
     /**
      * Originally developers used barrier blocks for its purpose.
@@ -1002,6 +1097,7 @@ public enum XMaterial {
     SWEET_BERRY_BUSH("1.14", "GRASS", ""),
     TALL_GRASS(2, "DOUBLE_PLANT"),
     TALL_SEAGRASS(2, "1.13", "TALL_GRASS", ""),
+    TARGET("1.16"),
     TERRACOTTA("HARD_CLAY"),
     TIPPED_ARROW("1.9", "ARROW", ""),
     TNT,
@@ -1023,6 +1119,8 @@ public enum XMaterial {
     TURTLE_EGG("1.13", "EGG", ""),
     TURTLE_HELMET("1.13", "IRON_HELMET", ""),
     TURTLE_SPAWN_EGG("1.13", "CHICKEN_SPAWN_EGG", ""),
+    TWISTING_VINES("1.16"),
+    TWISTING_VINES_PLANT("1.16"),
     VEX_SPAWN_EGG(35, "MONSTER_EGG"),
     VILLAGER_SPAWN_EGG(120, "MONSTER_EGG"),
     VINDICATOR_SPAWN_EGG(36, "MONSTER_EGG"),
@@ -1035,6 +1133,24 @@ public enum XMaterial {
     VOID_AIR("AIR"),
     WALL_TORCH("TORCH"),
     WANDERING_TRADER_SPAWN_EGG("1.14", "VILLAGER_SPAWN_EGG", ""),
+    WARPED_BUTTON("1.16"),
+    WARPED_DOOR("1.16"),
+    WARPED_FENCE("1.16"),
+    WARPED_FENCE_GATE("1.16"),
+    WARPED_FUNGUS("1.16"),
+    WARPED_FUNGUS_ON_A_STICK("1.16"),
+    WARPED_HYPHAE("1.16"),
+    WARPED_NYLIUM("1.16"),
+    WARPED_PLANKS("1.16"),
+    WARPED_PRESSURE_PLATE("1.16"),
+    WARPED_ROOTS("1.16"),
+    WARPED_SIGN("1.16"),
+    WARPED_SLAB("1.16"),
+    WARPED_STAIRS("1.16"),
+    WARPED_STEM("1.16"),
+    WARPED_TRAPDOOR("1.16"),
+    WARPED_WALL_SIGN("1.16"),
+    WARPED_WART_BLOCK("1.16"),
     /**
      * This is used for blocks only.
      * In 1.13- WATER will turn into STATIONARY_WATER after it finished spreading.
@@ -1044,6 +1160,8 @@ public enum XMaterial {
      */
     WATER("STATIONARY_WATER"),
     WATER_BUCKET,
+    WEEPING_VINES("1.16"),
+    WEEPING_VINES_PLANT("1.16"),
     WET_SPONGE(1, "SPONGE"),
     /**
      * Wheat is a known material in pre-1.13
@@ -1052,16 +1170,16 @@ public enum XMaterial {
     WHEAT("CROPS"),
     WHEAT_SEEDS("SEEDS"),
     WHITE_BANNER(15, "BANNER", "STANDING_BANNER"),
-    WHITE_BED("BED", "BED_BLOCK"),
+    WHITE_BED("BED_BLOCK", "BED"),
     WHITE_CARPET("CARPET"),
     WHITE_CONCRETE("CONCRETE"),
     WHITE_CONCRETE_POWDER("CONCRETE_POWDER"),
     WHITE_DYE(15, "1.14", "INK_SACK", "BONE_MEAL"),
-    WHITE_GLAZED_TERRACOTTA("1.12", "HARD_CLAY", "STAINED_CLAY", "WHITE_TERRACOTTA"),
+    WHITE_GLAZED_TERRACOTTA("1.12", "HARD_CLAY", "STAINED_CLAY"),
     WHITE_SHULKER_BOX,
     WHITE_STAINED_GLASS("STAINED_GLASS"),
     WHITE_STAINED_GLASS_PANE("THIN_GLASS", "STAINED_GLASS_PANE"),
-    WHITE_TERRACOTTA("HARD_CLAY", "TERRACOTTA"),
+    WHITE_TERRACOTTA("HARD_CLAY", "STAINED_CLAY", "TERRACOTTA"),
     WHITE_TULIP(6, "RED_ROSE"),
     WHITE_WALL_BANNER(15, "WALL_BANNER"),
     WHITE_WOOL("WOOL"),
@@ -1079,7 +1197,7 @@ public enum XMaterial {
     WRITABLE_BOOK("BOOK_AND_QUILL"),
     WRITTEN_BOOK,
     YELLOW_BANNER(11, "BANNER", "STANDING_BANNER"),
-    YELLOW_BED(4, "BED", "BED_BLOCK"),
+    YELLOW_BED(4, "BED_BLOCK", "BED"),
     YELLOW_CARPET(4, "CARPET"),
     YELLOW_CONCRETE(4, "CONCRETE"),
     YELLOW_CONCRETE_POWDER(4, "CONCRETE_POWDER"),
@@ -1096,7 +1214,8 @@ public enum XMaterial {
     ZOMBIE_PIGMAN_SPAWN_EGG(57, "MONSTER_EGG"),
     ZOMBIE_SPAWN_EGG(54, "MONSTER_EGG"),
     ZOMBIE_VILLAGER_SPAWN_EGG(27, "MONSTER_EGG"),
-    ZOMBIE_WALL_HEAD(2, "SKULL", "SKULL_ITEM");
+    ZOMBIE_WALL_HEAD(2, "SKULL", "SKULL_ITEM"),
+    ZOMBIFIED_PIGLIN_SPAWN_EGG(54, "MONSTER_EGG");
 
 
     /**
@@ -1132,16 +1251,26 @@ public enum XMaterial {
      * @since 3.0.0
      */
     @SuppressWarnings("UnstableApiUsage")
-    private static final ImmutableMap<XMaterial, XMaterial> DUPLICATED = Maps.immutableEnumMap(ImmutableMap.<XMaterial, XMaterial>builder()
+    private static final ImmutableMap<XMaterial, XMaterial> duplicated = Maps.immutableEnumMap(ImmutableMap.<XMaterial, XMaterial>builder()
             .put(MELON, MELON_SLICE)
             .put(CARROT, CARROTS)
             .put(POTATO, POTATOES)
             .put(BEETROOT, BEETROOTS)
             .put(BROWN_MUSHROOM, BROWN_MUSHROOM_BLOCK)
             .put(BRICK, BRICKS)
-            .put(RED_MUSHROOM, RED_MUSHROOM_BLOCK)
-            .put(MAP, FILLED_MAP)
             .put(NETHER_BRICK, NETHER_BRICKS)
+
+            // Illegal Elements
+            // Since both 1.12 and 1.13 have <type>_DOOR XMaterial will use it
+            // for 1.12 to parse the material, but it needs <type>_DOOR_ITEM.
+            // We'll trick XMaterial into thinking this needs to be parsed
+            // using the old methods.
+            .put(DARK_OAK_DOOR, DARK_OAK_DOOR)
+            .put(ACACIA_DOOR, ACACIA_DOOR)
+            .put(BIRCH_DOOR, BIRCH_DOOR)
+            .put(JUNGLE_DOOR, JUNGLE_DOOR)
+            .put(SPRUCE_DOOR, SPRUCE_DOOR)
+
             .build()
     );
     /*
@@ -1232,7 +1361,7 @@ public enum XMaterial {
      * An invocation of this method yields the cached result from the expression:
      * <p>
      * <blockquote>
-     * {@link #supports(int 13)}}
+     * {@link #supports(int) 13}}
      * </blockquote>
      *
      * @return true if 1.13 or higher.
@@ -1283,13 +1412,14 @@ public enum XMaterial {
     @Nullable
     private static XMaterial requestOldXMaterial(@Nonnull String name, byte data) {
         String holder = name + data;
-        XMaterial material = NAME_CACHE.getIfPresent(holder);
-        if (material != null) return material;
+        XMaterial cache = NAME_CACHE.getIfPresent(holder);
+        if (cache != null) return cache;
 
-        for (XMaterial materials : VALUES) {
-            if ((data == -1 || data == materials.data) && materials.anyMatchLegacy(name)) {
-                NAME_CACHE.put(holder, materials);
-                return materials;
+        for (XMaterial material : VALUES) {
+            // Not using material.name().equals(name) check is intended.
+            if ((data == -1 || data == material.data) && material.anyMatchLegacy(name)) {
+                NAME_CACHE.put(holder, material);
+                return material;
             }
         }
 
@@ -1320,37 +1450,15 @@ public enum XMaterial {
     /**
      * Parses the given material name as an XMaterial with unspecified data value.
      *
-     * @see #matchXMaterial(String, byte)
+     * @see #matchXMaterialWithData(String)
      * @since 2.0.0
      */
     @Nonnull
     public static Optional<XMaterial> matchXMaterial(@Nonnull String name) {
-        return matchXMaterial(name, (byte) -1);
-    }
-
-    /**
-     * Parses the given material name as an XMaterial.
-     * Can also be used like: <b>MATERIAL:DATA</b>
-     * <p>
-     * <b>Examples</b>
-     * <pre>
-     *     INK_SACK:1 -> RED_DYE
-     *     WOOL, 14  -> RED_WOOL
-     * </pre>
-     *
-     * @see #matchDefinedXMaterial(String, byte)
-     * @see #matchXMaterial(ItemStack)
-     * @since 2.0.0
-     */
-    @Nonnull
-    public static Optional<XMaterial> matchXMaterial(@Nonnull String name, byte data) {
         Validate.notEmpty(name, "Cannot match a material with null or empty material name");
         Optional<XMaterial> oldMatch = matchXMaterialWithData(name);
         if (oldMatch.isPresent()) return oldMatch;
-
-        // -1 Determines whether the item's data value is unknown and only the name is given.
-        // Checking if the item is damageable won't do anything as the data is not going to be checked in requestOldMaterial anyway.
-        return matchDefinedXMaterial(format(name), data);
+        return matchDefinedXMaterial(format(name), (byte) -1);
     }
 
     /**
@@ -1360,8 +1468,8 @@ public enum XMaterial {
      * <p>
      * <b>Examples</b>
      * <p><pre>
-     *     INK_SACK:1 -> RED_DYE
-     *     WOOL, 14  -> RED_WOOL
+     *     {@code INK_SACK:1 -> RED_DYE}
+     *     {@code WOOL, 14  -> RED_WOOL}
      * </pre>
      *
      * @param name the material string that consists of the material name, data and separator character.
@@ -1394,7 +1502,7 @@ public enum XMaterial {
     public static XMaterial matchXMaterial(@Nonnull Material material) {
         Objects.requireNonNull(material, "Cannot match null material");
         return matchDefinedXMaterial(material.name(), (byte) -1)
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported Material: " + material));
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported Material With No Bytes: " + material.name()));
     }
 
     /**
@@ -1411,9 +1519,10 @@ public enum XMaterial {
     public static XMaterial matchXMaterial(@Nonnull ItemStack item) {
         Objects.requireNonNull(item, "Cannot match null ItemStack");
         String material = item.getType().name();
-        return matchDefinedXMaterial(material,
-                isDamageable(material) ? (byte) 0 : (byte) item.getDurability())
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported Material: " + material));
+        byte data = (byte) (ISFLAT || isDamageable(material) ? 0 : item.getDurability());
+
+        return matchDefinedXMaterial(material, data)
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported Material: " + material + " (" + data + ')'));
     }
 
     /**
@@ -1423,7 +1532,6 @@ public enum XMaterial {
      * @param name the formatted name of the material.
      * @param data the data value of the material.
      * @return an XMaterial (with the same data value if specified)
-     * @see #matchXMaterial(String, byte)
      * @see #matchXMaterial(Material)
      * @see #matchXMaterial(int, byte)
      * @see #matchXMaterial(ItemStack)
@@ -1436,7 +1544,7 @@ public enum XMaterial {
         // Do basic number and boolean checks before accessing more complex enum stuff.
         // Maybe we can simplify (ISFLAT || !duplicated) with the (!ISFLAT && duplicated) under it to save a few nanoseconds?
         // if (!Boolean.valueOf(Boolean.getBoolean(Boolean.TRUE.toString())).equals(Boolean.FALSE.booleanValue())) return null;
-        if (data <= 0 && (ISFLAT || !duplicated)) {
+        if (data <= 0 && !duplicated) {
             // Apparently the transform method is more efficient than toJavaUtil()
             // toJavaUtil isn't even supported in older versions.
             Optional<XMaterial> xMat = Enums.getIfPresent(XMaterial.class, name).transform(Optional::of).or(Optional.empty());
@@ -1447,8 +1555,20 @@ public enum XMaterial {
         // I've concluded that this is just an infinite loop that keeps
         // going around the Singular Form and the Plural Form materials. A waste of brain cells and a waste of time.
         // This solution works just fine anyway.
-        if (!ISFLAT && duplicated) return Optional.ofNullable(requestDuplicatedXMaterial(name, data));
-        return Optional.ofNullable(requestOldXMaterial(name, data));
+        XMaterial xMat = requestOldXMaterial(name, data);
+        if (xMat == null) {
+            // Special case. Refer to FILLED_MAP for more info.
+            if (data > 0 && name.endsWith("MAP")) return Optional.of(FILLED_MAP);
+            return Optional.empty();
+        }
+
+        if (!ISFLAT && duplicated && xMat.name().charAt(xMat.name().length() - 1) == 'S') {
+            // A solution for XMaterial Paradox.
+            // Manually parses the duplicated materials to find the exact material based on the server version.
+            // If ends with "S" -> Plural Form Material
+            return Enums.getIfPresent(XMaterial.class, name).transform(Optional::of).or(Optional.empty());
+        }
+        return Optional.ofNullable(xMat);
     }
 
     /**
@@ -1463,13 +1583,12 @@ public enum XMaterial {
      * @see #isDuplicated()
      * @since 2.0.0
      */
-    public static boolean isDuplicated(@Nonnull String name) {
-        Validate.notEmpty(name, "Cannot check duplication for null or empty material name");
-        name = format(name);
-
+    private static boolean isDuplicated(@Nonnull String name) {
         // Don't use matchXMaterial() since this method is being called from matchXMaterial() itself and will cause a StackOverflowError.
-        for (Map.Entry<XMaterial, XMaterial> duplicated : DUPLICATED.entrySet())
-            if (duplicated.getKey().name().equals(name) || duplicated.getKey().anyMatchLegacy(name)) return true;
+        for (Map.Entry<XMaterial, XMaterial> duplicated : duplicated.entrySet()) {
+            XMaterial material = duplicated.getKey();
+            if (material.name().equals(name) || material.anyMatchLegacy(name)) return true;
+        }
         return false;
     }
 
@@ -1494,60 +1613,6 @@ public enum XMaterial {
     }
 
     /**
-     * A solution for <b>XMaterial Paradox</b>.
-     * Manually parses the duplicated materials to find the exact material based on the server version.
-     *
-     * @param name the name of the material.
-     * @return the duplicated XMaterial based on the version.
-     * @throws IllegalArgumentException may be thrown. If thrown, it's a bug.
-     * @since 2.0.0
-     */
-    @Nullable
-    private static XMaterial requestDuplicatedXMaterial(@Nonnull String name, byte data) {
-        XMaterial mat = requestOldXMaterial(name, data);
-        // If ends with "S" -> Plural Form Material
-        return mat.name().charAt(mat.name().length() - 1) == 'S' ? Enums.getIfPresent(XMaterial.class, name).orNull() : mat;
-    }
-
-    /**
-     * Always returns the value with the given duplicated material key name.
-     *
-     * @param name the name of the material.
-     * @return the new XMaterial of this duplicated material.
-     * @see #getXMaterialIfDuplicated(String)
-     * @since 2.0.0
-     */
-    @Nonnull
-    public static Optional<XMaterial> getNewXMaterialIfDuplicated(@Nonnull String name) {
-        Validate.notEmpty(name, "Cannot get new duplicated material for null or empty material name");
-        name = format(name);
-
-        for (Map.Entry<XMaterial, XMaterial> duplicated : DUPLICATED.entrySet())
-            if (duplicated.getKey().name().equals(name)) return Optional.of(duplicated.getKey());
-        return Optional.empty();
-    }
-
-    /**
-     * Checks if the item is duplicated for a different purpose in new versions from {@link #DUPLICATED}.
-     *
-     * @param name the name of the material.
-     * @return the other XMaterial (key or value) of the XMaterial (key or value).
-     * @see #matchXMaterial(String, byte)
-     * @since 2.0.0
-     */
-    @Nullable
-    public static XMaterial getXMaterialIfDuplicated(@Nonnull String name) {
-        Validate.notEmpty(name, "Cannot get duplicated material for null or empty material name");
-        name = format(name);
-
-        for (Map.Entry<XMaterial, XMaterial> duplicated : DUPLICATED.entrySet())
-            if (duplicated.getKey().name().equals(name)) return duplicated.getValue();
-            else if (duplicated.getValue().name().equals(name)) return duplicated.getKey();
-
-        return null;
-    }
-
-    /**
      * Attempts to build the string like an enum name.
      * Removes all the spaces, numbers and extra non-English characters. Also removes some config/in-game based strings.
      *
@@ -1564,7 +1629,7 @@ public enum XMaterial {
     /**
      * Checks if the specified version is the same version or higher than the current server version.
      *
-     * @param version the major version to be checked. "1." is ignored -> 1.12 = 12 | 1.9 = 9
+     * @param version the major version to be checked. "1." is ignored. E.g. 1.12 = 12 | 1.9 = 9
      * @return true of the version is equal or higher than the current version.
      * @since 2.0.0
      */
@@ -1663,14 +1728,14 @@ public enum XMaterial {
      * <br>
      * <b>{@code CONTAINS} Examples:</b>
      * <pre>
-     *     "CONTAINS:CHEST" -> CHEST, ENDERCHEST, TRAPPED_CHEST -> true
-     *     "cOnTaINS:dYe" -> GREEN_DYE, YELLOW_DYE, BLUE_DYE, INK_SACK -> true
+     *     {@code "CONTAINS:CHEST" -> CHEST, ENDERCHEST, TRAPPED_CHEST -> true}
+     *     {@code "cOnTaINS:dYe" -> GREEN_DYE, YELLOW_DYE, BLUE_DYE, INK_SACK -> true}
      * </pre>
      * <p>
      * <b>{@code REGEX} Examples</b>
      * <pre>
-     *     "REGEX:^.+_.+_.+$" -> Every Material with 3 underlines or more: SHULKER_SPAWN_EGG, SILVERFISH_SPAWN_EGG, SKELETON_HORSE_SPAWN_EGG
-     *     "REGEX:^.{1,3}$" -> Material names that have 3 letters only: BED, MAP, AIR
+     *     {@code "REGEX:^.+_.+_.+$" -> Every Material with 3 underlines or more: SHULKER_SPAWN_EGG, SILVERFISH_SPAWN_EGG, SKELETON_HORSE_SPAWN_EGG}
+     *     {@code "REGEX:^.{1,3}$" -> Material names that have 3 letters only: BED, MAP, AIR}
      * </pre>
      * <p>
      * The reason that there are tags for {@code CONTAINS} and {@code REGEX}
@@ -1803,8 +1868,7 @@ public enum XMaterial {
      */
     @SuppressWarnings("deprecation")
     public int getId() {
-        if (this.data != 0 || (this.legacy.length != 0 && Integer.parseInt(this.legacy[0].substring(2)) >= 13))
-            return -1;
+        if (this.data != 0 || (this.legacy.length != 0 && Integer.parseInt(this.legacy[0].substring(2)) >= 13)) return -1;
         Material material = this.parseMaterial();
         return material == null ? -1 : material.getId();
     }
@@ -1813,25 +1877,11 @@ public enum XMaterial {
      * Checks if the material has any duplicates.
      *
      * @return true if there is a duplicated name for this material, otherwise false.
-     * @see #getXMaterialIfDuplicated()
      * @see #isDuplicated(String)
      * @since 2.0.0
      */
     public boolean isDuplicated() {
-        return DUPLICATED.containsKey(this);
-    }
-
-    /**
-     * Checks if the item is duplicated for a different purpose in new versions.
-     *
-     * @return true if the item's name is duplicated, otherwise false.
-     * @see #isDuplicated()
-     * @see #getNewXMaterialIfDuplicated(String)
-     * @since 2.0.0
-     */
-    @Nullable
-    public XMaterial getXMaterialIfDuplicated() {
-        return DUPLICATED.get(this);
+        return duplicated.containsKey(this);
     }
 
     /**
@@ -1891,7 +1941,7 @@ public enum XMaterial {
      * Parses an item from this XMaterial.
      * Uses data values on older versions.
      *
-     * @param suggest if true {@link #parseMaterial(boolean true)} will be used.
+     * @param suggest if true {@link #parseMaterial(boolean)} true will be used.
      * @return an ItemStack with the same material (and data value if in older versions.)
      * @see #setType(ItemStack)
      * @since 2.0.0
@@ -1921,7 +1971,6 @@ public enum XMaterial {
      *
      * @param suggest use a suggested material (from older materials) if the material is added in a later version of Minecraft.
      * @return the material related to this XMaterial based on the server version.
-     * @see #matchXMaterial(String, byte)
      * @since 2.0.0
      */
     @SuppressWarnings("OptionalAssignedToNull")

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -1272,7 +1272,7 @@ public enum TL {
     SAFEZONE("safezone", "&6Safezone"),
     SAFEZONE_DESCRIPTION("safezone-description", "Free from pvp and monsters."),
     TOGGLE_SB("toggle-sb", "You now have scoreboards set to {value}"),
-    FACTION_LEAVE("faction-leave", "Leaving %1$s, Entering %2$s"),
+    FACTION_LEAVE("faction-leave", "Leaving %1$s&r, Entering %2$s&r"),
     FACTIONS_ANNOUNCEMENT_TOP("faction-announcement-top", "&d--Unread Faction Announcements--"),
     FACTIONS_ANNOUNCEMENT_BOTTOM("faction-announcement-bottom", "&d--Unread Faction Announcements--"),
     DEFAULT_PREFIX("default-prefix", "{relationcolor}[{faction}]"),


### PR DESCRIPTION
JDA v3.x has been deprecated and out of support for well over a year and should not be used. The JDA v3 lib could randomly stop working at any point and migration to v4 should be performed ASAP.

Everything to know about migration of 3.x to 4.x is well documented on their official wiki: https://github.com/DV8FromTheWorld/JDA/wiki/0%29-Migrating-to-V4