### PR TITLE
Zero max relation doesn't need extra checking

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/relational/FRelationCommand.java
+++ b/src/main/java/com/massivecraft/factions/cmd/relational/FRelationCommand.java
@@ -113,6 +113,10 @@ public abstract class FRelationCommand extends FCommand {
     private boolean hasMaxRelations(Faction us, Faction them, Relation targetRelation) {
         int max = FactionsPlugin.getInstance().getConfig().getInt("max-relations." + targetRelation.toString(), -1);
         if (FactionsPlugin.getInstance().getConfig().getBoolean("max-relations.enabled", false)) {
+            if (max == 0) {
+                us.msg(TL.COMMAND_RELATIONS_EXCEEDS_ME, max, targetRelation.getPluralTranslation());
+                return true;
+            }
             if (max != -1) {
                 if (us.getRelationCount(targetRelation) >= max) {
                     us.msg(TL.COMMAND_RELATIONS_EXCEEDS_ME, max, targetRelation.getPluralTranslation());


### PR DESCRIPTION
Avoid doing all the other checks when the max for a relation is set to 0.

```yaml
max-relations:
  enabled: true
  ally: 0
  ...
```