### PR TITLE
%players.leader.id%

### DIFF
--- a/src/main/java/com/massivecraft/factions/integration/dynmap/EngineDynmap.java
+++ b/src/main/java/com/massivecraft/factions/integration/dynmap/EngineDynmap.java
@@ -71,9 +71,11 @@ public class EngineDynmap {
         }
         return ret.toString();
     }
-
     public static String getHtmlPlayerName(FPlayer fplayer) {
         return fplayer != null ? escapeHtml(fplayer.getName()) : "none";
+    }
+    public static String getHtmlPlayerUUID(FPlayer fplayer) {
+        return fplayer != null ? escapeHtml(fplayer.getAccountId()) : "none";
     }
 
     public static String escapeHtml(String string) {
@@ -661,6 +663,7 @@ public class EngineDynmap {
 
         FPlayer playersLeaderObject = faction.getFPlayerAdmin();
         String playersLeader = getHtmlPlayerName(playersLeaderObject);
+        String playersLeaderId = getHtmlPlayerUUID(playersLeaderObject);
 
         ArrayList<FPlayer> playersCoAdminsList = faction.getFPlayersWhereRole(Role.COLEADER);
         String playersCoAdminsCount = String.valueOf(playersCoAdminsList.size());
@@ -677,6 +680,7 @@ public class EngineDynmap {
         ret = ret.replace("%players%", players);
         ret = ret.replace("%players.count%", playersCount);
         ret = ret.replace("%players.leader%", playersLeader);
+        ret = ret.replace("%players.leader.id%", playersLeaderId);
         ret = ret.replace("%players.admins%", playersCoAdmins);
         ret = ret.replace("%players.admins.count%", playersCoAdminsCount);
         ret = ret.replace("%players.moderators%", playersModerators);


### PR DESCRIPTION
Adds the ability to embed the faction leader's ID in the Dynmap popup html (`dynmapDescription`) using `%players.leader.id%`.

Were it not for it breaking everyone's configs I would change `%players.leader%` to be `%players.leader.username%` but 🎼 we can't always get what we want. 🎼