### PR TITLE
Adds LunarClientWrapper class to allow for reflection on main class.

### DIFF
--- a/src/main/java/com/massivecraft/factions/FactionsPlugin.java
+++ b/src/main/java/com/massivecraft/factions/FactionsPlugin.java
@@ -15,6 +15,7 @@ import com.massivecraft.factions.cmd.audit.FLogType;
 import com.massivecraft.factions.cmd.chest.AntiChestListener;
 import com.massivecraft.factions.cmd.reserve.ReserveAdapter;
 import com.massivecraft.factions.cmd.reserve.ReserveObject;
+import com.massivecraft.factions.integration.LunarClientWrapper;
 import com.massivecraft.factions.integration.Worldguard;
 import com.massivecraft.factions.listeners.*;
 import com.massivecraft.factions.missions.MissionHandler;
@@ -90,7 +91,7 @@ public class FactionsPlugin extends MPlugin {
     private boolean mvdwPlaceholderAPIManager = false;
     private Listener[] eventsListener;
     private Worldguard wg;
-    public LunarClientAPI lunarClientAPI;
+    public LunarClientWrapper lcWrapper;
 
     public FactionsPlugin() {
         instance = this;
@@ -425,8 +426,8 @@ public class FactionsPlugin extends MPlugin {
         this.fLogManager.log(faction, type, arguments);
     }
 
-    public LunarClientAPI getLunarClientAPI() {
-        return lunarClientAPI;
+    public LunarClientWrapper getLunarClientWrapper() {
+        return lcWrapper;
     }
 
     public List<ReserveObject> getFactionReserves() {

--- a/src/main/java/com/massivecraft/factions/integration/LunarAPI.java
+++ b/src/main/java/com/massivecraft/factions/integration/LunarAPI.java
@@ -23,7 +23,7 @@ public class LunarAPI {
         if(fPlayer.hasFaction() && fPlayer.getFaction().getHome() != null) {
             //FactionsPlugin.getInstance().getLunarClientAPI().registerPlayer(player);
             LCWaypoint waypoint = new LCWaypoint("Faction Home", faction.getHome(), Color.LIME.asRGB(), true);
-            FactionsPlugin.getInstance().getLunarClientAPI().sendWaypoint(player, waypoint);
+            FactionsPlugin.getInstance().getLunarClientWrapper().getLcAPI().sendWaypoint(player, waypoint);
         }
     }
 

--- a/src/main/java/com/massivecraft/factions/integration/LunarClientWrapper.java
+++ b/src/main/java/com/massivecraft/factions/integration/LunarClientWrapper.java
@@ -1,0 +1,15 @@
+package com.massivecraft.factions.integration;
+
+import com.lunarclient.bukkitapi.LunarClientAPI;
+
+public class LunarClientWrapper {
+    private final LunarClientAPI lcAPI;
+
+    public LunarClientAPI getLcAPI() {
+        return lcAPI;
+    }
+
+    public LunarClientWrapper(LunarClientAPI lcAPI){
+        this.lcAPI = lcAPI;
+    }
+}

--- a/src/main/java/com/massivecraft/factions/zcore/util/StartupParameter.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/StartupParameter.java
@@ -12,6 +12,7 @@ import com.massivecraft.factions.cmd.reserve.ReserveObject;
 import com.massivecraft.factions.discord.Discord;
 import com.massivecraft.factions.integration.Econ;
 import com.massivecraft.factions.integration.Essentials;
+import com.massivecraft.factions.integration.LunarClientWrapper;
 import com.massivecraft.factions.integration.dynmap.EngineDynmap;
 import com.massivecraft.factions.util.Logger;
 import com.massivecraft.factions.util.Metrics;
@@ -67,7 +68,7 @@ public class StartupParameter {
         EngineDynmap.getInstance().init();
 
         if(Bukkit.getPluginManager().isPluginEnabled("LunarClient-API")) {
-            FactionsPlugin.getInstance().lunarClientAPI = LunarClientAPI.getInstance();
+            FactionsPlugin.getInstance().lcWrapper = new LunarClientWrapper(LunarClientAPI.getInstance());
             Logger.print("Implementing Lunar Client Integration", Logger.PrefixType.DEFAULT);
         }
 


### PR DESCRIPTION
This should allow plugins that need to use reflection on the main class without LunarClientAPI in the classpath.