### PR TITLE
fixed removed worlds breaking plugin & ensure worlds load before factions

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -101,6 +101,7 @@ public class Conf {
     public static boolean removePlayerDataWhenBanned = true;
     public static String removePlayerDataWhenBannedReason = "Banned by admin.";
     public static boolean autoLeaveDeleteFPlayerData = true; // Let them just remove player from Faction.
+    public static boolean removeInvalidClaims = false;
     public static boolean worldGuardChecking = false;
     public static boolean worldGuardBuildPriority = false;
 

--- a/src/main/java/com/massivecraft/factions/FLocation.java
+++ b/src/main/java/com/massivecraft/factions/FLocation.java
@@ -122,7 +122,7 @@ public final class FLocation implements Serializable {
     }
 
     public String getWorldName() {
-        return getWorld().getName();
+        return this.world;
     }
 
     @Deprecated

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -154,12 +154,10 @@ public class FactionsChatListener implements Listener {
 
         if (!Conf.chatTagReplaceString.isEmpty() && eventFormat.contains(Conf.chatTagReplaceString)) {
             // we're using the "replace" method of inserting the faction tags
-            eventFormat = TextUtil.replace(TextUtil.replace(
-                    eventFormat,
-                    "[FACTION_TITLE]", me.getTitle()),
-                    Conf.chatTagReplaceString, "");
+            eventFormat = TextUtil.replace(eventFormat, "[FACTION_TITLE]", me.getTitle());
 
             insertIndex = eventFormat.indexOf(Conf.chatTagReplaceString);
+            eventFormat = TextUtil.replace(eventFormat, Conf.chatTagReplaceString, "");
             Conf.chatTagPadAfter = false;
             Conf.chatTagPadBefore = false;
         } else if (!Conf.chatTagInsertAfterString.isEmpty() && eventFormat.contains(Conf.chatTagInsertAfterString)) {

--- a/src/main/java/com/massivecraft/factions/util/Logger.java
+++ b/src/main/java/com/massivecraft/factions/util/Logger.java
@@ -23,20 +23,18 @@ public class Logger {
         DEBUG(ChatColor.YELLOW + "DEBUG: "),
         WARNING(ChatColor.RED + "WARNING: "),
         NONE(""),
-        DEFAULT(ChatColor.GOLD + "[SaberFactions] "),
+        DEFAULT(ChatColor.GOLD.toString()),
         HEADLINE(ChatColor.GOLD + ""),
         FAILED(ChatColor.RED + "FAILED: ");
 
         private final String prefix;
 
         PrefixType(String prefix) {
-            this.prefix = prefix;
+            this.prefix = ChatColor.GOLD + "[SaberFactions] " + prefix;
         }
 
         public String getPrefix() {
             return this.prefix;
         }
-
     }
-
 }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -184,14 +184,18 @@ public abstract class MemoryBoard extends Board {
             String id = entry.getValue();
 
             String worldName = location.getWorldName();
-            if (Bukkit.getWorld(worldName) == null) {
-                Logger.print("No world '" + worldName + "' found. Removed or not loaded?");
+            if (Bukkit.getWorld(worldName) != null) {
+                if (Factions.getInstance().isValidFactionId(id)) {
+                    continue;
+                }
+            } else {
+                if (!Conf.removeInvalidClaims) {
+                    Logger.print("No world '" + worldName + "' found. Removed or not loaded?. Enable removeInvalidClaims in Conf.json to remove these claims.");
+                    continue;
+                }
             }
-
-            if (!Factions.getInstance().isValidFactionId(id)) {
-                Logger.print("Board cleaner removed " + id + " from " + location, Logger.PrefixType.DEFAULT);
-                iter.remove();
-            }
+            Logger.print("Board cleaner removed " + id + " from " + location);
+            iter.remove();
         }
     }
 

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -14,6 +14,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import com.massivecraft.factions.util.CC;
 import org.bukkit.World;
@@ -175,11 +176,20 @@ public abstract class MemoryBoard extends Board {
     }
 
     public void clean() {
-        Iterator<Entry<FLocation, String>> iter = flocationIds.entrySet().iterator();
+        Iterator<Entry<FLocation, String>> iter = this.flocationIds.entrySet().iterator();
         while (iter.hasNext()) {
             Entry<FLocation, String> entry = iter.next();
-            if (!Factions.getInstance().isValidFactionId(entry.getValue())) {
-                Logger.print("Board cleaner removed " + entry.getValue() + " from " + entry.getKey(), Logger.PrefixType.DEFAULT);
+
+            FLocation location = entry.getKey();
+            String id = entry.getValue();
+
+            String worldName = location.getWorldName();
+            if (Bukkit.getWorld(worldName) == null) {
+                Logger.print("No world '" + worldName + "' found. Removed or not loaded?");
+            }
+
+            if (!Factions.getInstance().isValidFactionId(id)) {
+                Logger.print("Board cleaner removed " + id + " from " + location, Logger.PrefixType.DEFAULT);
                 iter.remove();
             }
         }

--- a/src/main/java/com/massivecraft/factions/zcore/util/DiscUtil.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/DiscUtil.java
@@ -3,11 +3,12 @@ package com.massivecraft.factions.zcore.util;
 import com.massivecraft.factions.FactionsPlugin;
 import org.bukkit.Bukkit;
 
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -25,7 +26,7 @@ public class DiscUtil {
             Files.createFile(path);
         }
 
-        try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(path, StandardOpenOption.WRITE))) {
+        try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(path))) {
             out.write(bytes);
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ api-version: 1.13
 main: com.massivecraft.factions.FactionsPlugin
 authors: [Olof Larsson, Brett Flannigan, drtshock, ProSavage, DroppingAnvil, Driftay, SaberDev, Callum, Atilt]
 depend: [Vault]
-softdepend: [CoreProtect, PlayerVaults, PlaceholderAPI, MVdWPlaceholderAPI, PermissionsEx, Permissions, Essentials, EssentialsChat, HeroChat, iChat, LocalAreaChat, LWC, nChat, ChatManager, CAPI, AuthMe, Vault, Spout, WorldEdit, WorldGuard, AuthDB, CaptureThePoints, CombatTag, dynmap, FactionsTop, WildStacker]
+softdepend: [CoreProtect, PlayerVaults, PlaceholderAPI, MVdWPlaceholderAPI, PermissionsEx, Permissions, Essentials, EssentialsChat, HeroChat, iChat, LocalAreaChat, LWC, nChat, ChatManager, CAPI, AuthMe, Vault, Spout, WorldEdit, WorldGuard, AuthDB, CaptureThePoints, CombatTag, dynmap, FactionsTop, WildStacker, Multiverse-Core]
 commands:
   factions:
     description: Reference command for Factions.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ api-version: 1.13
 main: com.massivecraft.factions.FactionsPlugin
 authors: [Olof Larsson, Brett Flannigan, drtshock, ProSavage, DroppingAnvil, Driftay, SaberDev, Callum, Atilt]
 depend: [Vault]
-softdepend: [CoreProtect, PlayerVaults, PlaceholderAPI, MVdWPlaceholderAPI, PermissionsEx, Permissions, Essentials, EssentialsChat, HeroChat, iChat, LocalAreaChat, LWC, nChat, ChatManager, CAPI, AuthMe, Vault, Spout, WorldEdit, WorldGuard, AuthDB, CaptureThePoints, CombatTag, dynmap, FactionsTop, WildStacker, Multiverse-Core]
+softdepend: [CoreProtect, PlayerVaults, PlaceholderAPI, MVdWPlaceholderAPI, PermissionsEx, Permissions, Essentials, EssentialsChat, HeroChat, iChat, LocalAreaChat, LWC, nChat, ChatManager, CAPI, AuthMe, Vault, Spout, WorldEdit, WorldGuard, AuthDB, CaptureThePoints, CombatTag, dynmap, FactionsTop, WildStacker, Multiverse-Core, MultiWorld]
 commands:
   factions:
     description: Reference command for Factions.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,5 @@
 name: Factions
+prefix: SaberFactions
 version: ${project.version}
 api-version: 1.13
 main: com.massivecraft.factions.FactionsPlugin


### PR DESCRIPTION
- fixed removed worlds breaking the plugin (invalid flocation initialization)
- flocation now returns the cached world instead of parsing through bukkit then back
- ensure worlds through popular multi-world plugins are loaded first (MV-Core, MultiWorld)