### PR TITLE
Fix Crop Boost Upgrade

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/frame/fupgrades/UpgradesListener.java
+++ b/src/main/java/com/massivecraft/factions/zcore/frame/fupgrades/UpgradesListener.java
@@ -12,10 +12,8 @@ import com.massivecraft.factions.util.Logger;
 import com.massivecraft.factions.zcore.frame.fupgrades.provider.stackers.RoseStackerProvider;
 import com.massivecraft.factions.zcore.frame.fupgrades.provider.stackers.WildStackerProvider;
 import org.bukkit.Bukkit;
-import org.bukkit.CropState;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.entity.Entity;
@@ -28,12 +26,9 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.SpawnerSpawnEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
-import org.bukkit.material.Crops;
 import org.bukkit.plugin.Plugin;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class UpgradesListener implements Listener {
@@ -45,8 +40,9 @@ public class UpgradesListener implements Listener {
 
     private WildStackerProvider wildStackerProvider;
     private RoseStackerProvider roseStackerProvider;
-    private HashSet<Material> cropMaterials;
+
     private Material sugarCaneMaterial;
+    private Set<Material> cropMaterials;
 
     public void init() {
         Plugin wildStacker = Bukkit.getPluginManager().getPlugin("WildStacker");
@@ -119,7 +115,14 @@ public class UpgradesListener implements Listener {
     private void growCrop(BlockGrowEvent e) {
         Material type = e.getBlock().getType();
         if (cropMaterials == null) {
-            cropMaterials = new HashSet<>(Arrays.asList(XMaterial.WHEAT.parseMaterial(), XMaterial.BEETROOTS.parseMaterial(), XMaterial.CARROTS.parseMaterial(), XMaterial.POTATOES.parseMaterial(), XMaterial.NETHER_WART.parseMaterial(), XMaterial.COCOA.parseMaterial()));
+            cropMaterials = EnumSet.of(
+                    XMaterial.WHEAT.parseMaterial(),
+                    XMaterial.BEETROOT.parseMaterial(),
+                    XMaterial.CARROTS.parseMaterial(),
+                    XMaterial.POTATOES.parseMaterial(),
+                    XMaterial.NETHER_WART.parseMaterial(),
+                    XMaterial.COCOA.parseMaterial()
+            );
             sugarCaneMaterial = XMaterial.SUGAR_CANE.parseMaterial();
         }
         if (cropMaterials.contains(type)) { // ageable single block crop (wheat, beetroot, etc.)

--- a/src/main/java/com/massivecraft/factions/zcore/frame/fupgrades/UpgradesListener.java
+++ b/src/main/java/com/massivecraft/factions/zcore/frame/fupgrades/UpgradesListener.java
@@ -17,6 +17,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.data.Ageable;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -112,23 +113,26 @@ public class UpgradesListener implements Listener {
     }
 
     private void growCrop(BlockGrowEvent e) {
-        if (e.getBlock().getType().equals(XMaterial.WHEAT.parseMaterial())) {
+        Material type = e.getBlock().getType();
+        if (type.equals(XMaterial.WHEAT.parseMaterial()) || type.equals(XMaterial.BEETROOTS.parseMaterial()) || type.equals(XMaterial.CARROTS.parseMaterial()) || type.equals(XMaterial.POTATOES.parseMaterial()) || type.equals(XMaterial.NETHER_WART.parseMaterial()) || type.equals(XMaterial.COCOA.parseMaterial())) {
             e.setCancelled(true);
-            Crops c = new Crops(CropState.RIPE);
-            BlockState bs = e.getBlock().getState();
-            bs.setData(c);
-            bs.update();
-        }
-        Block below = e.getBlock().getLocation().subtract(0.0, 1.0, 0.0).getBlock();
-        if (below.getType() == XMaterial.SUGAR_CANE.parseMaterial()) {
-            Block above = e.getBlock().getLocation().add(0.0, 1.0, 0.0).getBlock();
-            if (above.getType() == Material.AIR && above.getLocation().add(0.0, -2.0, 0.0).getBlock().getType() != Material.AIR) {
-                above.setType(XMaterial.SUGAR_CANE.parseMaterial());
-            }
-        } else if (below.getType() == Material.CACTUS) {
-            Block above = e.getBlock().getLocation().add(0.0, 1.0, 0.0).getBlock();
-            if (above.getType() == Material.AIR && above.getLocation().add(0.0, -2.0, 0.0).getBlock().getType() != Material.AIR) {
-                above.setType(Material.CACTUS);
+            Ageable ageable = (Ageable) e.getBlock().getBlockData();
+            int newAge = ageable.getAge() + 2;
+            if (newAge > ageable.getMaximumAge()) newAge = ageable.getMaximumAge();
+            ageable.setAge(newAge);
+            e.getBlock().setBlockData(ageable);
+        } else {
+            Block below = e.getBlock().getLocation().subtract(0.0, 1.0, 0.0).getBlock();
+            if (below.getType() == XMaterial.SUGAR_CANE.parseMaterial()) {
+                Block above = e.getBlock().getLocation().add(0.0, 1.0, 0.0).getBlock();
+                if (above.getType() == Material.AIR && above.getLocation().add(0.0, -2.0, 0.0).getBlock().getType() != Material.AIR) {
+                    above.setType(XMaterial.SUGAR_CANE.parseMaterial());
+                }
+            } else if (below.getType() == Material.CACTUS) {
+                Block above = e.getBlock().getLocation().add(0.0, 1.0, 0.0).getBlock();
+                if (above.getType() == Material.AIR && above.getLocation().add(0.0, -2.0, 0.0).getBlock().getType() != Material.AIR) {
+                    above.setType(Material.CACTUS);
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes the crop boost upgrade by making it more like one would expect based on the description. It now grows crops by an extra stage, rather than just setting them to fully grown instantly, and works for all ageable crops (wheat, beetroots, carrots, potatoes, netherwart, and cocoa) 