### PR TITLE
feat: Add Sethome and Delhome event

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
@@ -39,7 +39,7 @@ public class CmdDelHome extends FCommand {
             return;
         }
 
-        FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.player, context.faction);
+        FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.faction, context.fPlayer);
         Bukkit.getPluginManager().callEvent(delHomeEvent);
         if (delHomeEvent.isCancelled()) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
@@ -40,7 +40,7 @@ public class CmdDelHome extends FCommand {
         }
 
         FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.faction, context.fPlayer);
-        Bukkit.getPluginManager().callEvent(delHomeEvent);
+        Bukkit.getServer().getPluginManager().callEvent(delHomeEvent);
         if (delHomeEvent.isCancelled()) {
             return;
         }

--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
@@ -2,9 +2,11 @@ package com.massivecraft.factions.cmd;
 
 import com.massivecraft.factions.Conf;
 import com.massivecraft.factions.FactionsPlugin;
+import com.massivecraft.factions.event.FactionDelHomeEvent;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.fperms.PermissableAction;
 import com.massivecraft.factions.zcore.util.TL;
+import org.bukkit.Bukkit;
 
 /**
  * Factions - Developed by Driftay.
@@ -34,6 +36,12 @@ public class CmdDelHome extends FCommand {
         if (!context.faction.hasHome()) {
             context.msg(TL.COMMAND_HOME_NOHOME.toString());
             context.msg(FactionsPlugin.getInstance().cmdBase.cmdSethome.getUsageTemplate(context));
+            return;
+        }
+
+        FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.faction);
+        Bukkit.getPluginManager().callEvent(delHomeEvent);
+        if (delHomeEvent.isCancelled()) {
             return;
         }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelHome.java
@@ -39,7 +39,7 @@ public class CmdDelHome extends FCommand {
             return;
         }
 
-        FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.faction);
+        FactionDelHomeEvent delHomeEvent = new FactionDelHomeEvent(context.player, context.faction);
         Bukkit.getPluginManager().callEvent(delHomeEvent);
         if (delHomeEvent.isCancelled()) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
@@ -27,55 +27,53 @@ public class CmdSethome extends FCommand {
 
     @Override
     public void perform(CommandContext context) {
-        FactionsPlugin.getInstance().getServer().getScheduler().runTaskAsynchronously(FactionsPlugin.instance, () -> {
-            if (!Conf.homesEnabled) {
-                context.msg(TL.COMMAND_SETHOME_DISABLED);
+        if (!Conf.homesEnabled) {
+            context.msg(TL.COMMAND_SETHOME_DISABLED);
+            return;
+        }
+
+        Faction faction = context.argAsFaction(0, context.faction);
+        if (faction == null) {
+            return;
+        }
+
+        // trigger the faction set home event (cancellable)
+        FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(faction, context.fPlayer, context.player.getLocation());
+        Bukkit.getServer().getPluginManager().callEvent(setHomeEvent);
+        if (setHomeEvent.isCancelled()) {
+            return;
+        }
+
+        // Can the player set the faction home HERE?
+        if (!Permission.BYPASS.has(context.player) &&
+                Conf.homesMustBeInClaimedTerritory &&
+                Board.getInstance().getFactionAt(FLocation.wrap(context.player)) != faction) {
+            context.msg(TL.COMMAND_SETHOME_NOTCLAIMED);
+            return;
+        }
+
+        if (!context.args.isEmpty()) {
+            Faction target = context.argAsFaction(0);
+            if (target == null) return;
+            context.faction = target;
+            if (target.getAccess(context.fPlayer, PermissableAction.SETHOME) != Access.ALLOW) {
+                context.fPlayer.msg(TL.GENERIC_FPERM_NOPERMISSION, "set faction home");
                 return;
             }
+        }
 
-            Faction faction = context.argAsFaction(0, context.faction);
-            if (faction == null) {
-                return;
-            }
+        // if economy is enabled, they're not on the bypass list, and this command has a cost set, make 'em pay
+        if (!context.payForCommand(Conf.econCostSethome, TL.COMMAND_SETHOME_TOSET, TL.COMMAND_SETHOME_FORSET)) {
+            return;
+        }
 
-            // trigger the faction set home event (cancellable)
-            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(faction, context.fPlayer, context.player.getLocation());
-            Bukkit.getPluginManager().callEvent(setHomeEvent);
-            if (setHomeEvent.isCancelled()) {
-                return;
-            }
+        faction.setHome(context.player.getLocation());
 
-            // Can the player set the faction home HERE?
-            if (!Permission.BYPASS.has(context.player) &&
-                    Conf.homesMustBeInClaimedTerritory &&
-                    Board.getInstance().getFactionAt(FLocation.wrap(context.player)) != faction) {
-                context.msg(TL.COMMAND_SETHOME_NOTCLAIMED);
-                return;
-            }
-
-            if (!context.args.isEmpty()) {
-                Faction target = context.argAsFaction(0);
-                if (target == null) return;
-                context.faction = target;
-                if (target.getAccess(context.fPlayer, PermissableAction.SETHOME) != Access.ALLOW) {
-                    context.fPlayer.msg(TL.GENERIC_FPERM_NOPERMISSION, "set faction home");
-                    return;
-                }
-            }
-
-            // if economy is enabled, they're not on the bypass list, and this command has a cost set, make 'em pay
-            if (!context.payForCommand(Conf.econCostSethome, TL.COMMAND_SETHOME_TOSET, TL.COMMAND_SETHOME_FORSET)) {
-                return;
-            }
-
-            faction.setHome(context.player.getLocation());
-
-            faction.msg(TL.COMMAND_SETHOME_SET, context.fPlayer.describeTo(context.faction, true));
-            faction.sendMessage(FactionsPlugin.getInstance().cmdBase.cmdHome.getUsageTemplate(context));
-            if (faction != context.faction) {
-                context.msg(TL.COMMAND_SETHOME_SETOTHER, faction.getTag(context.fPlayer));
-            }
-        });
+        faction.msg(TL.COMMAND_SETHOME_SET, context.fPlayer.describeTo(context.faction, true));
+        faction.sendMessage(FactionsPlugin.getInstance().cmdBase.cmdHome.getUsageTemplate(context));
+        if (faction != context.faction) {
+            context.msg(TL.COMMAND_SETHOME_SETOTHER, faction.getTag(context.fPlayer));
+        }
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
@@ -1,10 +1,12 @@
 package com.massivecraft.factions.cmd;
 
 import com.massivecraft.factions.*;
+import com.massivecraft.factions.event.FactionSetHomeEvent;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.fperms.Access;
 import com.massivecraft.factions.zcore.fperms.PermissableAction;
 import com.massivecraft.factions.zcore.util.TL;
+import org.bukkit.Bukkit;
 
 public class CmdSethome extends FCommand {
 
@@ -33,6 +35,13 @@ public class CmdSethome extends FCommand {
 
             Faction faction = context.argAsFaction(0, context.faction);
             if (faction == null) {
+                return;
+            }
+
+            // trigger the faction set home event (cancellable)
+            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(faction);
+            Bukkit.getPluginManager().callEvent(setHomeEvent);
+            if (setHomeEvent.isCancelled()) {
                 return;
             }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
@@ -39,7 +39,7 @@ public class CmdSethome extends FCommand {
             }
 
             // trigger the faction set home event (cancellable)
-            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(faction);
+            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(context.player, faction);
             Bukkit.getPluginManager().callEvent(setHomeEvent);
             if (setHomeEvent.isCancelled()) {
                 return;

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
@@ -39,7 +39,7 @@ public class CmdSethome extends FCommand {
             }
 
             // trigger the faction set home event (cancellable)
-            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(context.player, faction);
+            FactionSetHomeEvent setHomeEvent = new FactionSetHomeEvent(faction, context.fPlayer, context.player.getLocation());
             Bukkit.getPluginManager().callEvent(setHomeEvent);
             if (setHomeEvent.isCancelled()) {
                 return;

--- a/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
@@ -1,0 +1,32 @@
+package com.massivecraft.factions.event;
+
+import com.massivecraft.factions.Faction;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Event called when a Faction sets their home.
+ */
+public class FactionDelHomeEvent extends FactionEvent implements Cancellable {
+
+    /**
+     * @author NewZ_AZ
+     */
+
+    private boolean cancelled;
+
+    public FactionDelHomeEvent(Faction faction) {
+        super(faction);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+
+}

--- a/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
@@ -1,10 +1,11 @@
 package com.massivecraft.factions.event;
 
 import com.massivecraft.factions.Faction;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
 /**
- * Event called when a Faction sets their home.
+ * Event called when a Faction deletes their home.
  */
 public class FactionDelHomeEvent extends FactionEvent implements Cancellable {
 
@@ -12,10 +13,16 @@ public class FactionDelHomeEvent extends FactionEvent implements Cancellable {
      * @author NewZ_AZ
      */
 
+    private final Player sender;
     private boolean cancelled;
 
-    public FactionDelHomeEvent(Faction faction) {
+    public FactionDelHomeEvent(Player sender, Faction faction) {
         super(faction);
+        this.sender = sender;
+    }
+
+    public Player getPlayer() {
+        return sender;
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
@@ -1,5 +1,6 @@
 package com.massivecraft.factions.event;
 
+import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.Faction;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -7,22 +8,15 @@ import org.bukkit.event.Cancellable;
 /**
  * Event called when a Faction deletes their home.
  */
-public class FactionDelHomeEvent extends FactionEvent implements Cancellable {
+public class FactionDelHomeEvent extends FactionPlayerEvent implements Cancellable {
 
     /**
      * @author NewZ_AZ
      */
-
-    private final Player sender;
     private boolean cancelled;
 
-    public FactionDelHomeEvent(Player sender, Faction faction) {
-        super(faction);
-        this.sender = sender;
-    }
-
-    public Player getPlayer() {
-        return sender;
+    public FactionDelHomeEvent(Faction faction, FPlayer fPlayer) {
+        super(faction, fPlayer);
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionDelHomeEvent.java
@@ -13,7 +13,7 @@ public class FactionDelHomeEvent extends FactionPlayerEvent implements Cancellab
     /**
      * @author NewZ_AZ
      */
-    private boolean cancelled;
+    private boolean cancelled = false;
 
     public FactionDelHomeEvent(Faction faction, FPlayer fPlayer) {
         super(faction, fPlayer);

--- a/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
@@ -1,6 +1,7 @@
 package com.massivecraft.factions.event;
 
 import com.massivecraft.factions.Faction;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 
@@ -12,11 +13,16 @@ public class FactionSetHomeEvent extends FactionEvent implements Cancellable {
     /**
      * @author NewZ_AZ
      */
-
+    private final Player sender;
     private boolean cancelled;
 
-    public FactionSetHomeEvent(Faction faction) {
+    public FactionSetHomeEvent(Player sender, Faction faction) {
         super(faction);
+        this.sender = sender;
+    }
+
+    public Player getPlayer() {
+        return sender;
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
@@ -1,6 +1,8 @@
 package com.massivecraft.factions.event;
 
+import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.Faction;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -8,21 +10,21 @@ import org.bukkit.event.Event;
 /**
  * Event called when a Faction sets their home.
  */
-public class FactionSetHomeEvent extends FactionEvent implements Cancellable {
+public class FactionSetHomeEvent extends FactionPlayerEvent implements Cancellable {
 
     /**
      * @author NewZ_AZ
      */
-    private final Player sender;
+    private final Location location;
     private boolean cancelled;
 
-    public FactionSetHomeEvent(Player sender, Faction faction) {
-        super(faction);
-        this.sender = sender;
+    public FactionSetHomeEvent(Faction faction, FPlayer fPlayer, Location location) {
+        super(faction, fPlayer);
+        this.location = location;
     }
 
-    public Player getPlayer() {
-        return sender;
+    public Location getLocation() {
+        return location;
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
@@ -16,7 +16,7 @@ public class FactionSetHomeEvent extends FactionPlayerEvent implements Cancellab
      * @author NewZ_AZ
      */
     private final Location location;
-    private boolean cancelled;
+    private boolean cancelled = false;
 
     public FactionSetHomeEvent(Faction faction, FPlayer fPlayer, Location location) {
         super(faction, fPlayer);

--- a/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionSetHomeEvent.java
@@ -1,0 +1,33 @@
+package com.massivecraft.factions.event;
+
+import com.massivecraft.factions.Faction;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Event called when a Faction sets their home.
+ */
+public class FactionSetHomeEvent extends FactionEvent implements Cancellable {
+
+    /**
+     * @author NewZ_AZ
+     */
+
+    private boolean cancelled;
+
+    public FactionSetHomeEvent(Faction faction) {
+        super(faction);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+
+}


### PR DESCRIPTION
- I need 2 events when faction use /f sethome, and another for /f delhome