### PR TITLE
Fix start issues on 1.20.x and 1.21

### DIFF
--- a/src/main/java/com/massivecraft/factions/util/ReflectionUtils.java
+++ b/src/main/java/com/massivecraft/factions/util/ReflectionUtils.java
@@ -397,7 +397,16 @@ public final class ReflectionUtils {
          * @return The server version
          */
         public static String getServerVersion() {
-            return Bukkit.getServer().getClass().getPackage().getName().substring(23);
+            try {
+                return Bukkit.getServer().getClass().getPackage().getName().substring(23);
+            } catch (IndexOutOfBoundsException e) {
+                String versionFull = Bukkit.getServer().getVersion();
+                String substring = versionFull.substring(versionFull.indexOf("(") + 1, versionFull.lastIndexOf(")") - 1);
+                while (substring.contains(".")) {
+                    substring = substring.replace(".", "_");
+                }
+                return substring;
+            }
         }
 
         /**


### PR DESCRIPTION
Fixes an issue where the Bukkit.getServer().getClass().getPackage().getName() function no longer shows the minecraft version number required by the onEnable method in FactionsPlugin.java.

The log that has been fixed
```
[11:46:16 INFO]: [SaberFactions] Enabling Factions v1.6.9.5-4.1.6-BETA
[11:46:16 ERROR]: Error occurred while enabling Factions v1.6.9.5-4.1.6-BETA (Is it up to date?)
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
        at SaberFactions.jar/com.massivecraft.factions.FactionsPlugin.onEnable(FactionsPlugin.java:141) ~[SaberFactions.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:288) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:626) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:575) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:675) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:437) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
[11:46:16 INFO]: [SaberFactions] Disabling Factions v1.6.9.5-4.1.6-BETA
[11:46:16 INFO]: [SaberFactions] ===== Shutdown Start =====
[11:46:16 ERROR]: Error occurred while disabling Factions v1.6.9.5-4.1.6-BETA
java.lang.NullPointerException: Cannot invoke "com.massivecraft.factions.zcore.util.Persist.saveSync(Object)" because "com.massivecraft.factions.FactionsPlugin.instance.persist" is null
        at SaberFactions.jar/com.massivecraft.factions.Conf.saveSync(Conf.java:653) ~[SaberFactions.jar:?]
        at SaberFactions.jar/com.massivecraft.factions.zcore.util.ShutdownParameter.initShutdown(ShutdownParameter.java:18) ~[SaberFactions.jar:?]
        at SaberFactions.jar/com.massivecraft.factions.FactionsPlugin.onDisable(FactionsPlugin.java:288) ~[SaberFactions.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:291) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:237) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugin(PaperPluginManagerImpl.java:114) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.plugin.SimplePluginManager.disablePlugin(SimplePluginManager.java:550) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:206) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:626) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:575) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:675) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:437) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

This is just a fix for papermc, haven't tried any other servers