### PR TITLE
Add territoryTruceDenyCommands to configuration

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -204,6 +204,7 @@ public class Conf {
     public static Set<String> permanentFactionMemberDenyCommands = new LinkedHashSet<>();
     // commands which will be prevented when in claimed territory of another faction
     public static Set<String> territoryNeutralDenyCommands = new LinkedHashSet<>();
+    public static Set<String> territoryTruceDenyCommands = new LinkedHashSet<>();
     public static Set<String> territoryEnemyDenyCommands = new LinkedHashSet<>();
     public static Set<String> territoryAllyDenyCommands = new LinkedHashSet<>();
     public static Set<String> warzoneDenyCommands = new LinkedHashSet<>();

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -262,6 +262,11 @@ public class FactionsPlayerListener implements Listener {
             return true;
         }
 
+        if (at.isNormal() && rel.isTruce() && !Conf.territoryTruceDenyCommands.isEmpty() && !me.isAdminBypassing() && isCommandInList(fullCmd, shortCmd, Conf.territoryTruceDenyCommands.iterator())) {
+            me.msg(TL.PLAYER_COMMAND_TRUCE, fullCmd);
+            return true;
+        }
+
         if (at.isNormal() && rel.isNeutral() && !Conf.territoryNeutralDenyCommands.isEmpty() && !me.isAdminBypassing() && isCommandInList(fullCmd, shortCmd, Conf.territoryNeutralDenyCommands.iterator())) {
             me.msg(TL.PLAYER_COMMAND_NEUTRAL, fullCmd);
             return true;

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -1391,6 +1391,7 @@ public enum TL {
     PLAYER_COMMAND_ENEMY("You can't use the command '%s' in enemy territory."),
     PLAYER_COMMAND_PERMANENT("You can't use the command '%s' because you are in a permanent faction."),
     PLAYER_COMMAND_ALLY("You can't use the command '%s' in ally territory."),
+    PLAYER_COMMAND_TRUCE("You can't use the command '%s' in truce territory."),
     PLAYER_COMMAND_WILDERNESS("You can't use the command '%s' in the wilderness."),
 
     PLAYER_POWER_NOLOSS_PEACEFUL("You didn't lose any power since you are in a peaceful faction."),


### PR DESCRIPTION
I had a situation where people could abuse the fact that often truces were misunderstood as  neutral. We would have disallowed setHome for neutral and enemy, but enemies could become truce and then bypass the denyCommand settings.

Therefore I propose that territoryTruceDenyCommands should be added as a setting, just like enemy, neutral and ally.