### PR TITLE
Fix typo in TL.java

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -192,7 +192,7 @@ public enum TL {
     COMMAND_ALTKICK_NOTMEMBER("&c&l[!] &7This player is not a member of your faction."),
 
     COMMAND_ALTS_LIST_NOALTS("&c&l[!] &7%s does not have any alts in their faction!"),
-    COMMAND_AUTOHELP_HECOMMAND_LEAVE_LEADER_MESSAGELPFOR("Help for command"),
+    COMMAND_AUTOHELP_HELPFOR("Help for command"),
     COMMAND_HOME_OTHER_NOTSET("&c&l[!] &7%s does not have their faction home set!"),
     COMMAND_HOME_TELEPORT_OTHER("&c&l[!] &7You have teleported to %s's faction home!"),
     COMMAND_SHOP_DESCRIPTION("opens shop gui"),


### PR DESCRIPTION
(cherry picked from commit 1498dcaded2046918fd54c274f2440f48acbbbd1)

Fixes a typo in TL.java, that caused compilation failures