### PR TITLE
Fix PlaceholderAPI dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,9 +338,9 @@
         </dependency>
 
         <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>2.11.2</version>
+            <groupId>com.github.PlaceholderAPI</groupId>
+            <artifactId>PlaceholderAPI</artifactId>
+            <version>2.11.6</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
It seems the old dependency has been removed from jitpack.io, and has been replaced with the artifact `com.github.PlaceholderAPI:PlaceholderAPI`, which I have changed.

Alternatively one could keep the old me.clip:placeholderapi artifact, but it would be required that the HelpChat repository be added, which i think is their own repository

I.e adding 
```xml
        <repository>
            <id>helpchat-repo</id>
            <url>https://repo.extendedclip.com/</url>
        </repository>
```
would also fix the issue